### PR TITLE
Fix asset manifest

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'manifest' => get_theme_file_path().'/dist/assets.json',
+    'manifest' => get_theme_file_path().'/dist/mix-manifest.json',
 
     /*
     |--------------------------------------------------------------------------

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -37,3 +37,14 @@ mix.options({
 
 mix.sourceMaps(false, 'source-map')
    .version();
+
+mix.then(() => {
+  const manifest = File.find('./dist/mix-manifest.json');
+  const json = JSON.parse(manifest.read());
+  Object.keys(json).forEach(key => {
+    const hashed = json[key];
+    delete json[key];
+    json[key.replace(/^\/+/g, '')] = hashed.replace(/^\/+/g, '');
+  });
+  manifest.write(JSON.stringify(json, null, 2));
+});


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Now that we use [Laravel Mix](), an adjustment to the asset manifest generation is needed to make it work with sage-lib.

## Steps to test

Assets load with versioning hash appended as query string.

## Additional information

See: https://github.com/roots/sage/pull/2011/files#diff-4b01fcde499a24e105e55a22b2351174

## Related issues
Not applicable.
