### PR TITLE
feat: add current filter controls

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -26,7 +26,7 @@ class App extends Controller
         if ($wp_query->tax_query) {
             foreach ($wp_query->tax_query->queries as $value) {
                 foreach ($value['terms'] as $t) {
-                    $terms[$value['taxonomy']][] = $t;
+                    $terms[$value['taxonomy']][$t] = get_term_by('slug', $t, $value['taxonomy']);
                 }
             }
         }
@@ -51,6 +51,21 @@ class App extends Controller
     public function currentLanguage()
     {
         return pll_current_language();
+    }
+
+    public function foundPosts()
+    {
+        global $wp_query;
+        return $wp_query->found_posts;
+    }
+
+    public static function totalPosts($post_type = null)
+    {
+        if ($post_type) {
+            return wp_count_posts($post_type)->publish;
+        }
+
+        return 0;
     }
 
     public static function title()

--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -52,6 +52,16 @@ export default {
     if ( sortMenuButtonContainer ) {
       new Pinecone.MenuButton( sortMenuButtonContainer, { placement: 'bottom' } );
     }
+
+    const clearFilterBtns = document.querySelectorAll('.current-filters button');
+    Array.prototype.forEach.call( clearFilterBtns, btn => {
+      btn.onclick = () => {
+        const id = btn.getAttribute('data-checkbox');
+        const checkbox = document.getElementById(id);
+        checkbox.checked = false;
+        document.forms.filters.submit();
+      };
+    });
   },
   finalize() {
     // JavaScript to be fired on the home page, after the init JS

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -1,1 +1,15 @@
-{{-- TODO: Add current filter display --}}
+  @if(!empty(array_filter($queried_resource_terms)))
+  <div class="current-filters">
+    <p class="h3">Showing {{ $found_posts }} of {{ App::totalPosts('lc_resource') }} resources</p>
+    <ul class="tag-buttons">
+      @foreach($queried_resource_terms as $taxonomy)
+        @foreach($taxonomy as $term)
+        <li class="tag-button">
+          <button class="tag-button__button"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{{ $term->name }}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
+        </li>
+        @endforeach
+      @endforeach
+    </ul>
+  <p><a href="{{ get_post_type_archive_link('lc_resource') }}">{{ __('Clear all', 'coop-library') }}</a></p>
+  </div>
+@endif

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -5,7 +5,7 @@
       @foreach($queried_resource_terms as $taxonomy)
         @foreach($taxonomy as $term)
         <li class="tag-button">
-          <button class="tag-button__button"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{{ $term->name }}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
+          <button class="tag-button__button" data-checkbox="{{ $term->taxonomy }}-{{ $term->slug }}"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{{ $term->name }}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
         </li>
         @endforeach
       @endforeach

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -1,6 +1,6 @@
 <div class="filter-wrapper">
   <button type="button" class="button" id="show-filters">@svg('filter', 'icon--filter', ['focusable' => 'false', 'aria-hidden' => 'true']) {{ __('Filter', 'coop-library' ) }}</button>
-    <form class="filters" action="{{ get_post_type_archive_link('lc_resource') }}">
+    <form name="filters" class="filters" action="{{ get_post_type_archive_link('lc_resource') }}">
       <button type="button" class="button" id="hide-filters">{{ __('Close', 'coop-library' ) }} @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
       <h2 class="h1 screen-reader-text">{{ __('Filters', 'coop-library' ) }}</h2>
       <div class="accordion accordion--filter-list">
@@ -36,7 +36,7 @@
         @endforeach
       </div>
       <div class="input-group">
-        <input type="submit" name="submit" value="{{ __('Apply Filters', 'coop-library') }}" />
+        <input type="submit" name="applyFilters" value="{{ __('Apply Filters', 'coop-library') }}" />
       </div>
   </form>
 </div>

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -1,10 +1,4 @@
 <div class="filter-wrapper">
-  {{--<pre>
-  @php
-      global $wp_query;
-      print_r($queried_resource_terms);
-  @endphp
-  </pre>--}}
   <button type="button" class="button" id="show-filters">@svg('filter', 'icon--filter', ['focusable' => 'false', 'aria-hidden' => 'true']) {{ __('Filter', 'coop-library' ) }}</button>
     <form class="filters" action="{{ get_post_type_archive_link('lc_resource') }}">
       <button type="button" class="button" id="hide-filters">{{ __('Close', 'coop-library' ) }} @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
@@ -29,7 +23,7 @@
               <li>
                 <input id="{{ $tax }}-{{ $term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $term->slug }}" {{
                 checked(
-                  (in_array($term->slug, $queried_resource_terms[$tax], true)) ? $term->slug : false,
+                  (in_array($term->slug, array_keys($queried_resource_terms[$tax]), true)) ? $term->slug : false,
                   $term->slug,
                   false
                 ) }} />

--- a/resources/views/partials/page-header.blade.php
+++ b/resources/views/partials/page-header.blade.php
@@ -1,3 +1,4 @@
 <div class="page-header">
+  <p class="breadcrumb"><a href="/">{{ __('Home', 'coop-library') }}</a></p>
   <h1>{!! App::title() !!}</h1>
 </div>

--- a/resources/views/partials/pagination.blade.php
+++ b/resources/views/partials/pagination.blade.php
@@ -1,3 +1,4 @@
+{{-- Keep PurgeCSS from removing these styles. --}}
 <nav class="navigation pagination" role="navigation" aria-label="Posts">
   <h2 class="screen-reader-text">Posts navigation</h2>
   <a class="prev page-numbers" href="/en/resources/">‹ <span class="screen-reader-text">previous resources</span></a>

--- a/resources/views/partials/pagination.blade.php
+++ b/resources/views/partials/pagination.blade.php
@@ -1,0 +1,9 @@
+<nav class="navigation pagination" role="navigation" aria-label="Posts">
+  <h2 class="screen-reader-text">Posts navigation</h2>
+  <a class="prev page-numbers" href="/en/resources/">‹ <span class="screen-reader-text">previous resources</span></a>
+  <div class="nav-links"><span aria-current="page" class="page-numbers current">2</span>
+  <a class="page-numbers" href="/en/resources/page/3/">3</a>
+  <span class="page-numbers dots">…</span>
+  <a class="page-numbers" href="/en/resources/page/10/">10</a>
+  <a class="next page-numbers" href="/en/resources/page/3/"> <span class="screen-reader-text">next resources</span> ›</a></div>
+</nav>

--- a/resources/views/partials/tinymce.blade.php
+++ b/resources/views/partials/tinymce.blade.php
@@ -1,1 +1,2 @@
+{{-- Keep PurgeCSS from removing these styles. --}}
 <body id="tinymce"></body>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds support for display a list of current filters at the top of the **Browse all** page, and allows users to clear individual filters by clicking the corresponding button in the current filter list.
 
## Steps to test

1. Visit `/en/resources`.
2. Apply some filters.
3. Attempt to clear individual filters and to clear all filters.

**Expected behavior:** The page reloads with new filters applied (with the cleared filter removed from the current list).

## Additional information

This functionality currently requires JavaScript. A progressively-enhanced approach would replace the buttons with links. For example, on this page:

`/en/resources/?lc_topic[]=platform-capitalism&lc_format[]=audio`

The "Remove Audio from current filters" button could be replaced with a link to this page:

`/en/resources/?lc_topic[]=platform-capitalism` 

This might necessitate adding a corresponding link style which would be used in cases where JavaScript is disabled.

## Related issues

- https://github.com/platform-coop-toolkit/pinecone/issues/95