### PR TITLE
feat: add resource permalink and actions

### DIFF
--- a/resources/assets/scripts/main.js
+++ b/resources/assets/scripts/main.js
@@ -6,6 +6,7 @@ import {ready} from './util/Ready';
 import common from './routes/common';
 import home from './routes/home';
 import archive from './routes/archive';
+import single from './routes/single';
 
 /** Populate Router instance with DOM routes */
 const routes = new Router({
@@ -15,6 +16,8 @@ const routes = new Router({
   home,
   // Archive page
   archive,
+  // Single resource
+  single,
 });
 
 // Load Events

--- a/resources/assets/scripts/routes/single.js
+++ b/resources/assets/scripts/routes/single.js
@@ -1,0 +1,18 @@
+import Pinecone from '@platform-coop-toolkit/pinecone';
+
+export default {
+  init() {
+    // JavaScript to be fired on a single resource page
+    const share = document.querySelector( '.share' );
+    if ( share ) {
+      new Pinecone.MenuButton( share );
+    }
+    const alternateLinks = document.querySelector( '.alternate-links' );
+    if ( alternateLinks ) {
+      new Pinecone.MenuButton( alternateLinks );
+    }
+  },
+  finalize() {
+    // JavaScript to be fired on a single resource page, after the init JS
+  },
+};

--- a/resources/views/partials/content-single-lc_resource.blade.php
+++ b/resources/views/partials/content-single-lc_resource.blade.php
@@ -41,10 +41,10 @@
       <span class="button__label">{{ __('Favorite', 'coop-library') }}</span>
     </button>
     <div class="share menu-button">
-      <h2 class="h3 menu-button__label">
+      <p class="h3 menu-button__label">
         @svg('share', 'icon--share', ['focusable' => 'false', 'aria-hidden' => 'true'])
         {{ __('Share', 'coop-library') }}
-      </h2>
+      </p>
       <ul class="link-list">
         <li class="link-list__item">
           <a href="https://twitter.com/intent/tweet/?text={{ urlencode(get_the_title()) }}&url={{ urlencode(get_permalink()) }}">Twitter</a>

--- a/resources/views/partials/content-single-lc_resource.blade.php
+++ b/resources/views/partials/content-single-lc_resource.blade.php
@@ -26,38 +26,69 @@
       <li class="tag"><a class="tag__link" href="{{ $topic['url'] }}"><span class="screen-reader-text">{{ __('Topic', 'coop-library') }}: </span>{{ $topic['name'] }}</a></li>
       @endforeach
     </ul>
+    <button id="suggest-edits" type="button" class="button">
+      @svg('edit', 'icon--edit', ['focusable' => 'false', 'aria-hidden' => 'true'])
+      <span class="button__label">{{ __('Suggest edits', 'coop-library') }}</span>
+    </button>
   </div>
   @endif
-  <div class="resource__cta"></div>
+  <div class="resource__cta">
+    <p class="wp-block-button"><a rel="external" class="wp-block-button__link" href="{{ Single::getPermanentLink() }}">{{ __('Visit full resource', 'coop-library') }} @svg('external', 'icon--external', ['focusable' => 'false', 'aria-hidden' => 'true'])</a></p>
+  </div>
   <div class="resource__actions">
-    <ul class="permalinks">
-      <li><a href="{{ Single::getPermanentLink() }}">{{ __('Visit full resource', 'coop-library') }}</a></li>
-      @if(Single::getPermaCcLinks())
-        @foreach(Single::getPermaCcLinks() as $link)
-          @if($loop->count > 1)
-            <li><a href="{{ $link }}">{{ sprintf(__('Visit resource on Perma.cc (%1$d of %2$d)', 'coop-library'), $loop->iteration, $loop->count) }}</a></li>
-          @else
-            <li><a href="{{ $link }}">{{ __('Visit resource on Perma.cc', 'coop-library') }}</a></li>
-          @endif
-        @endforeach
-      @endif
-      @if(Single::getWaybackMachineLinks())
-        @foreach(Single::getWaybackMachineLinks() as $link)
-          @if($loop->count > 1)
-            <li><a href="{{ $link }}">{{ sprintf(__('Visit resource on the Internet Archive (%1$d of %2$d)', 'coop-library'), $loop->iteration, $loop->count) }}</a></li>
-          @else
-            <li><a href="{{ $link }}">{{ __('Visit resource on the Internet Archive', 'coop-library') }}</a></li>
-          @endif
-        @endforeach
-      @endif
-    </ul>
-    <nav class="engage">
-      <ul>
-        <li><a href="#">Favourite</a></li>
-        <li><a href="#">Share</a></li>
-        <li><a href="#">Recommend</a></li>
+    <button id="favorite" type="button" class="button">
+      @svg('favourite', 'icon--favorite', ['focusable' => 'false', 'aria-hidden' => 'true'])
+      <span class="button__label">{{ __('Favorite', 'coop-library') }}</span>
+    </button>
+    <div class="share menu-button">
+      <h2 class="h3 menu-button__label">
+        @svg('share', 'icon--share', ['focusable' => 'false', 'aria-hidden' => 'true'])
+        {{ __('Share', 'coop-library') }}
+      </h2>
+      <ul class="link-list">
+        <li class="link-list__item">
+          <a href="https://twitter.com/intent/tweet/?text={{ urlencode(get_the_title()) }}&url={{ urlencode(get_permalink()) }}">Twitter</a>
+        </li>
+        <li class="link-list__item">
+          <a href="https://facebook.com/sharer/sharer.php?u={{ urlencode(get_permalink()) }}">Facebook</a>
+        </li>
+        <li class="link-list__item">
+          <a href="https://www.linkedin.com/shareArticle?mini=true&url={{ urlencode(get_permalink()) }}&title={{ urlencode(get_the_title()) }}">LinkedIn</a>
+        </li>
+        <li class="link-list__item">
+          <a href="mailto:?subject={{ get_the_title() }}&body={{ urlencode(get_permalink()) }}">{{ __('Email', 'coop-library') }}</a>
+        </li>
       </ul>
-    </nav>
+
+    </div>
+    <button id="report-broken-link" type="button" class="button">
+      <span class="button__label">{{ __('Report broken link', 'coop-library') }}</span>
+    </button>
+    @if(Single::getPermaCcLinks() || Single::getWaybackMachineLinks())
+    <div class="alternate-links menu-button">
+      <h2 class="h3 menu-button__label">{{ __('View alternate links', 'coop-library') }}</h2>
+      <ul class="link-list">
+        @if(Single::getPermaCcLinks())
+        @foreach(Single::getPermaCcLinks() as $link)
+        @if($loop->count > 1)
+        <li class="link-list__item"><a href="{{ $link }}">{{ sprintf(__('View on Perma.cc (%1$d of %2$d)', 'coop-library'), $loop->iteration, $loop->count) }}</a></li>
+        @else
+        <li class="link-list__item"><a href="{{ $link }}">{{ __('View on Perma.cc', 'coop-library') }}</a></li>
+        @endif
+        @endforeach
+        @endif
+        @if(Single::getWaybackMachineLinks())
+        @foreach(Single::getWaybackMachineLinks() as $link)
+        @if($loop->count > 1)
+        <li class="link-list__item"><a href="{{ $link }}">{{ sprintf(__('View on the Internet Archive (%1$d of %2$d)', 'coop-library'), $loop->iteration, $loop->count) }}</a></li>
+        @else
+        <li class="link-list__item"><a href="{{ $link }}">{{ __('View on the Internet Archive', 'coop-library') }}</a></li>
+        @endif
+        @endforeach
+        @endif
+      </ul>
+    </div>
+    @endif
   </div>
   @php comments_template('/partials/comments.blade.php') @endphp
 </article>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds single resource call-to-action ("View full resource"), as well as buttons to suggest edits, report broken links, and menu buttons for sharing and viewing alternate copies.

## Steps to test

1. Visit a single resource.
2. Test all features except "Suggest edit", "Favorite", and "Report broken link".

**Expected behavior:** They work.

## Additional information

"Suggest edit" and "Report broken link" depend on the pending wires for these interfaces. Favorite depends on the implementation of user data with local storage.

## Related issues

Not applicable.
