### PR TITLE
fix: provide context for resource format label (resolves #136)

### DIFF
--- a/resources/views/partials/content-lc_resource.blade.php
+++ b/resources/views/partials/content-lc_resource.blade.php
@@ -1,6 +1,6 @@
 <li @php post_class('card card--resource') @endphp>
   <header>
-    <span class="card__format">@svg(Archive::getFormatSlug(), 'icon--' . Archive::getFormatSlug(), ['focusable' => 'false', 'aria-hidden' => 'true']) {{ Archive::getFormat() }}</span>
+    <span class="card__format">@svg(Archive::getFormatSlug(), 'icon--' . Archive::getFormatSlug(), ['focusable' => 'false', 'aria-hidden' => 'true']) <span class="screen-reader-text">{{ __('resource format', 'coop-library') }}: </span>{{ Archive::getFormat() }}</span>
     @if($current_language !== Archive::getLanguage())
     <span class="card__sep"> &middot; </span>
     <span class="card__language">{{ $languages[Archive::getLanguage()] }}</span>

--- a/resources/views/partials/content-single-lc_resource.blade.php
+++ b/resources/views/partials/content-single-lc_resource.blade.php
@@ -1,7 +1,7 @@
 <article @php post_class() @endphp>
   <div class="page-header resource__header">
     <p class="resource__format">
-      @svg(Single::getFormatSlug(), 'icon--' . Single::getFormatSlug(), ['focusable' => 'false', 'aria-hidden' => 'true']) {{ Single::getFormat() }}
+      @svg(Single::getFormatSlug(), 'icon--' . Single::getFormatSlug(), ['focusable' => 'false', 'aria-hidden' => 'true']) <span class="screen-reader-text">{{ __('resource format', 'coop-library') }}: </span>{{ Single::getFormat() }}
     </p>
     <h1 class="resource__title">{!! get_the_title() !!}</h1>
     @if(Single::getPublisher() || Single::getRegion())


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Resolve #136 by adding visually hidden prefix to resource format.

## Steps to test

1. Visit single resource and examine content using a screen reader.

**Expected behavior:** Format label is read out as "resource format: academic article" (or whatever the format is).

## Additional information

Not applicable.

## Related issues

- Resolves #136.
