### PR TITLE
feat: add term archive views (resolve #125, resolve #126)

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -79,9 +79,11 @@ class App extends Controller
             }
             return __('Latest Posts', 'coop-library');
         }
-        if (is_post_type_archive('lc_resource')) {
-            return __('Resources', 'coop-library');
+
+        if (is_post_type_archive('lc_resource') || is_tax()) {
+            return __('Browse all', 'coop-library');
         }
+
         if (is_search()) {
             return sprintf(__('Search Results for %s', 'coop-library'), get_search_query());
         }

--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -6,4 +6,16 @@ use Sober\Controller\Controller;
 
 class Page extends Controller
 {
+    public function taxonomy()
+    {
+        global $post;
+
+        if (pll_get_post_language($post->ID) === 'en') {
+            return 'lc_' . rtrim(str_replace('-', '_', $post->post_name), 's');
+        } else {
+            $translations = pll_get_post_translations($post->ID);
+            $slug = get_post_field('post_name', $translations['en']);
+            return 'lc_' . rtrim(str_replace('-', '_', $slug), 's');
+        }
+    }
 }

--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Controllers;
+
+use Sober\Controller\Controller;
+
+class Page extends Controller
+{
+}

--- a/app/filters.php
+++ b/app/filters.php
@@ -94,11 +94,12 @@ add_filter('comments_template', function ($comments_template) {
  * Show twenty resources per page.
  */
 add_filter('pre_get_posts', function ($query) {
-    if (is_post_type_archive('lc_resource') && $query->is_main_query()) {
+    if ((is_post_type_archive('lc_resource') || is_tax()) && $query->is_main_query()) {
         $query->set('posts_per_page', 12);
         $query->set('meta_key', 'lc_resource_publication_year');
         $query->set('orderby', 'meta_value');
         $query->set('order', 'desc');
+        $query->set('lang', '');
     }
 });
 

--- a/resources/assets/styles/layouts/_pages.scss
+++ b/resources/assets/styles/layouts/_pages.scss
@@ -1,0 +1,14 @@
+.term-list {
+  .link-list {
+    margin-top: 0;
+  }
+
+  .link-list hr {
+    margin: rem(60) 0 0 calc(-1 * (50vw - 50%));
+    width: 100vw;
+  }
+
+  .link-list hr + h2 {
+    margin-top: rem(48);
+  }
+}

--- a/resources/assets/styles/layouts/_pages.scss
+++ b/resources/assets/styles/layouts/_pages.scss
@@ -11,4 +11,8 @@
   .link-list hr + h2 {
     margin-top: rem(48);
   }
+
+  .link-list li:not([class]) + .link-list__item {
+    margin-top: rem(48);
+  }
 }

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -11,12 +11,13 @@
           <li class="link-list__item">
             <a href="{{ get_term_link($term) }}">{!! $term->name !!}</a>
           </li>
-          @foreach(get_term_children($term->term_id, $taxonomy) as $child)
+          @foreach(get_terms(['taxonomy' => $taxonomy, 'parent' => $term->term_id]) as $child_term)
           <li class="link-list__item">
-            <a href="{{ get_term_link($child) }}">{!! get_term($child)->name !!}</a>
+            <a href="{{ get_term_link($child_term) }}">{!! $child_term->name !!}</a>
           </li>
-        @endforeach
+          @endforeach
         </ul>
+        <hr class="is-style-thick has-grey-200-background-color" />
       </li>
     @elseif(!$term->parent)
       <li class="link-list__item">

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -1,11 +1,29 @@
 @if(get_terms($taxonomy))
-<ul class="link-list">
+  <ul class="link-list">
   @foreach(get_terms($taxonomy) as $term)
-  <li class="link-list__item">
-    <a href="{{ get_term_link($term) }}">{!! $term->name !!}</a>
-  </li>
+    @if(get_term_children($term->term_id, $taxonomy))
+      <li>
+        <hr class="is-style-thick has-grey-200-background-color" />
+        <h2>{{ $term->name }}</h2>
+      </li>
+      <li>
+        <ul class="link-list">
+          <li class="link-list__item">
+            <a href="{{ get_term_link($term) }}">{!! $term->name !!}</a>
+          </li>
+          @foreach(get_term_children($term->term_id, $taxonomy) as $child)
+          <li class="link-list__item">
+            <a href="{{ get_term_link($child) }}">{!! get_term($child)->name !!}</a>
+          </li>
+        @endforeach
+        </ul>
+      </li>
+    @elseif(!$term->parent)
+      <li class="link-list__item">
+        <a href="{{ get_term_link($term) }}">{!! $term->name !!}</a>
+      </li>
+    @endif
   @endforeach
-</ul>
 @else
-<p>{{ sprintf(__('No %s found.'), strtolower(get_the_title())) }}</p>
+  <p>{{ sprintf(__('No %s found.'), strtolower(get_the_title())) }}</p>
 @endif

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -6,4 +6,6 @@
   </li>
   @endforeach
 </ul>
+@else
+<p>{{ sprintf(__('No %s found.'), strtolower(get_the_title())) }}</p>
 @endif

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -1,0 +1,9 @@
+@if(get_terms($taxonomy))
+<ul class="link-list">
+  @foreach(get_terms($taxonomy) as $term)
+  <li class="link-list__item">
+    <a href="{{ get_term_link($term) }}">{!! $term->name !!}</a>
+  </li>
+  @endforeach
+</ul>
+@endif

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -2,12 +2,14 @@
   <div class="current-filters">
     <p class="h3">Showing {{ $found_posts }} of {{ App::totalPosts('lc_resource') }} resources</p>
     <ul class="tag-buttons">
-      @foreach($queried_resource_terms as $taxonomy)
-        @foreach($taxonomy as $term)
+      @foreach($queried_resource_terms as $taxonomy => $terms)
+        @if($taxonomy !== 'language')
+        @foreach($terms as $term)
         <li class="tag-button">
           <button class="tag-button__button" data-checkbox="{{ $term->taxonomy }}-{{ $term->slug }}"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{{ $term->name }}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
         </li>
         @endforeach
+        @endif
       @endforeach
     </ul>
   <p><a href="{{ get_post_type_archive_link('lc_resource') }}">{{ __('Clear all', 'coop-library') }}</a></p>

--- a/resources/views/term-list.blade.php
+++ b/resources/views/term-list.blade.php
@@ -1,0 +1,11 @@
+{{--
+	Template Name: Term List
+--}}
+@extends('layouts.app')
+
+@section('content')
+  @while(have_posts()) @php the_post() @endphp
+    @include('partials.page-header')
+    @include('partials.content-term-list')
+  @endwhile
+@endsection


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds tag list pages and filtered views by goal, topic, format, and co-op type.

## Steps to test

1. Create a new page, called 'Topics'.
2. Change the template to 'Term List' (under 'Page Attributes' in the sidebar).
3. Visit the page.
4. Navigate to one of the topics.

**Expected behavior:** Layout matches design found on XD. When you navigate to one of the topics, you get a filtered resource view with that topic applied as the current filter.

## Additional information

Not applicable.

## Related issues

- Resolves #125.
- Resolves #126.
