### PR TITLE
fix: text encoding in tag labels (resolves #167)

### DIFF
--- a/app/Controllers/Partials/Resource.php
+++ b/app/Controllers/Partials/Resource.php
@@ -1,6 +1,5 @@
 <?php namespace App\Controllers\Partials;
 
-use Illuminate\Support\Str;
 use function App\maybe_swap_term;
 
 trait Resource
@@ -183,7 +182,7 @@ trait Resource
                 foreach ($goals as $goal) {
                     $goal = maybe_swap_term($goal);
                     $result[] = [
-                        'name' => Str::title($goal->name),
+                        'name' => $goal->name,
                         'url' => get_term_link($goal),
                     ];
                 }
@@ -209,7 +208,7 @@ trait Resource
                 foreach ($topics as $topic) {
                     $topic = maybe_swap_term($topic);
                     $result[] = [
-                        'name' => Str::title($topic->name),
+                        'name' => $topic->name,
                         'url' => get_term_link($topic),
                     ];
                 }

--- a/app/Controllers/Partials/Resource.php
+++ b/app/Controllers/Partials/Resource.php
@@ -86,14 +86,14 @@ trait Resource
         return false;
     }
 
-    public static function getPublisher()
+    public static function getPublisher($show_link = false)
     {
         global $post;
 
         if ($post->post_type == 'lc_resource') {
             $publisher_name = get_post_meta($post->ID, 'lc_resource_publisher_name', true);
             $publisher_link = get_post_meta($post->ID, 'lc_resource_publisher_link', true);
-            if ($publisher_name && $publisher_link) {
+            if ($publisher_name && $publisher_link && $show_link) {
                 return "<a rel='external publisher' href='{$publisher_link}'>{$publisher_name}</a>";
             } elseif ($publisher_name) {
                 return $publisher_name;

--- a/resources/assets/styles/layouts/_pages.scss
+++ b/resources/assets/styles/layouts/_pages.scss
@@ -16,3 +16,19 @@
     margin-top: rem(48);
   }
 }
+
+@include breakpoint-up(sm) {
+  .page.page-favorites main {
+    @include grid-column-span(8, 8);
+  }
+}
+
+@include breakpoint-up(lg) {
+  .page.home main {
+    @include grid-column-span(12, 12);
+
+    .card-list {
+
+    }
+  }
+}

--- a/resources/assets/styles/layouts/_pages.scss
+++ b/resources/assets/styles/layouts/_pages.scss
@@ -16,19 +16,3 @@
     margin-top: rem(48);
   }
 }
-
-@include breakpoint-up(sm) {
-  .page.page-favorites main {
-    @include grid-column-span(8, 8);
-  }
-}
-
-@include breakpoint-up(lg) {
-  .page.home main {
-    @include grid-column-span(12, 12);
-
-    .card-list {
-
-    }
-  }
-}

--- a/resources/views/partials/content-lc_resource.blade.php
+++ b/resources/views/partials/content-lc_resource.blade.php
@@ -17,7 +17,7 @@
   <div class="card__tags">
     <ul class="badges">
       @foreach(Archive::getTopics(2) as $topic)
-      <li class="badge"><span class="screen-reader-text">Topic: </span>{{ $topic['name'] }}</li>
+      <li class="badge"><span class="screen-reader-text">Topic: </span>{!! $topic['name'] !!}</li>
       @endforeach
     </ul>
     @if(Archive::getOverflowTopics())

--- a/resources/views/partials/content-single-lc_resource.blade.php
+++ b/resources/views/partials/content-single-lc_resource.blade.php
@@ -23,7 +23,7 @@
   <div class="resource__tags">
     <ul class="tags">
       @foreach(Single::getTopics() as $topic)
-      <li class="tag"><a class="tag__link" href="{{ $topic['url'] }}"><span class="screen-reader-text">{{ __('Topic', 'coop-library') }}: </span>{{ $topic['name'] }}</a></li>
+      <li class="tag"><a class="tag__link" href="{{ $topic['url'] }}"><span class="screen-reader-text">{{ __('Topic', 'coop-library') }}: </span>{!! $topic['name'] !!}</a></li>
       @endforeach
     </ul>
     {{-- <button id="suggest-edits" type="button" class="button">

--- a/resources/views/partials/content-single-lc_resource.blade.php
+++ b/resources/views/partials/content-single-lc_resource.blade.php
@@ -7,7 +7,7 @@
     @if(Single::getPublisher() || Single::getRegion())
     <p class="resource__meta">
     @if(Single::getPublisher())
-      <span class="resource__publisher byline vcard">{{ __('By', 'coop-library') }} {!! Single::getPublisher() !!}</span>
+      <span class="resource__publisher byline vcard">{{ __('By', 'coop-library') }} {!! Single::getPublisher(true) !!}</span>
     @endif
     @if(Single::getRegion())
       <span class="resource__locality">@svg('location', 'icon--location', ['focusable' => 'false', 'aria-hidden' => 'true']) {{ Archive::getRegion() }}</span>

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -4,7 +4,7 @@
     @if(get_term_children($term->term_id, $taxonomy))
       <li>
         <hr class="is-style-thick has-grey-200-background-color" />
-        <h2>{{ $term->name }}</h2>
+        <h2>{!! $term->name !!}</h2>
       </li>
       <li>
         <ul class="link-list">

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -6,7 +6,7 @@
         @if($taxonomy !== 'language')
         @foreach($terms as $term)
         <li class="tag-button">
-          <button class="tag-button__button" data-checkbox="{{ $term->taxonomy }}-{{ $term->slug }}"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{{ $term->name }}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
+          <button class="tag-button__button" data-checkbox="{{ $term->taxonomy }}-{{ $term->slug }}"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{!! $term->name !!}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
         </li>
         @endforeach
         @endif


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Ampersands were being encoded in resource topic labels on the single resource view, on resource cards, and on term lists. Links to publishers were being displayed on resource cards.

## Steps to test

1. Add a topic with an ampersand in the title.
2. Apply it to a resource.
3. Examine the resource card and single resource view.
4. Examine the term list in which the topic appears.

**Expected behavior:** The ampersand should be displayed normally (`&`), not encoded (`&amp;`). No publisher links appear on resource cards.

## Additional information

Not applicable.

## Related issues

- Resolves #167.
