### PR TITLE
fix: add fallback icons for new formats (resolves #169)

### DIFF
--- a/app/Controllers/Partials/Resource.php
+++ b/app/Controllers/Partials/Resource.php
@@ -137,14 +137,54 @@ trait Resource
             if ($formats) {
                 $format = maybe_swap_term($formats[0], 'en');
                 switch ($format->slug) {
-                    case 'presentation-slides':
-                        return 'presentation';
+                    case 'academic-paper':
+                    case 'thesis':
+                        return 'academic-paper';
                         break;
+                    case 'article':
+                    case 'document':
+                    case 'blog-post':
+                    case 'journal-article':
+                    case 'magazine-article':
+                    case 'newspaper-article':
+                    case 'web-article':
+                        return 'article';
+                        break;
+                    case 'audio':
                     case 'podcast':
+                    case 'radio-broadcast':
                         return 'audio';
                         break;
+                    case 'book':
+                        return 'book';
+                        break;
+                    case 'case-study':
+                        return 'case-study';
+                        break;
+                    case 'curriculum':
+                        return 'educational-curriculum';
+                        break;
+                    case 'film':
+                    case 'interview':
+                    case 'video':
+                        return 'video';
+                        break;
+                    case 'online-training-webinar':
+                        return 'online-training';
+                        break;
+                    case 'presentation-slide':
+                        return 'presentation';
+                        break;
+                    case 'report':
+                        return 'report';
+                        break;
+                    case 'software':
+                    case 'toolkit':
+                    case 'template':
+                        return 'toolkit';
+                        break;
                     default:
-                        return $format->slug;
+                        return 'article';
                 }
             }
         }

--- a/app/Controllers/Partials/Resource.php
+++ b/app/Controllers/Partials/Resource.php
@@ -172,7 +172,7 @@ trait Resource
                     case 'online-training-webinar':
                         return 'online-training';
                         break;
-                    case 'presentation-slide':
+                    case 'presentation-slides':
                         return 'presentation';
                         break;
                     case 'report':


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR assigns icons to all new formats.

## Steps to test

1. Visit home page/browse all resources page.

**Expected behavior:** All resources load with an icon assigned.

## Additional information

We will need to design new icons for some of the formats; however, this fix will prevent errors when accessing the development and staging sites in the interim.

## Related issues

- Resolves #169.
