### PR TITLE
fix: enable custom filter order (resolves #168)

### DIFF
--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -1,6 +1,6 @@
 @if(get_terms(['taxonomy' => $taxonomy]))
   <ul class="link-list">
-  @foreach(get_terms(['taxonomy' => $taxonomy]) as $term)
+  @foreach(get_terms(['taxonomy' => $taxonomy, 'orderby' => 'order']) as $term)
     @if(get_term_children($term->term_id, $taxonomy))
       <li>
         <hr class="is-style-thick has-grey-200-background-color" />

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -1,6 +1,6 @@
-@if(get_terms($taxonomy))
+@if(get_terms(['taxonomy' => $taxonomy]))
   <ul class="link-list">
-  @foreach(get_terms($taxonomy) as $term)
+  @foreach(get_terms(['taxonomy' => $taxonomy, 'orderby' => 'order']) as $term)
     @if(get_term_children($term->term_id, $taxonomy))
       <li>
         <hr class="is-style-thick has-grey-200-background-color" />
@@ -11,7 +11,7 @@
           <li class="link-list__item">
             <a href="{{ get_term_link($term) }}">{!! $term->name !!}</a>
           </li>
-          @foreach(get_terms(['taxonomy' => $taxonomy, 'parent' => $term->term_id]) as $child_term)
+          @foreach(get_terms(['taxonomy' => $taxonomy, 'parent' => $term->term_id, 'orderby' => 'name']) as $child_term)
           <li class="link-list__item">
             <a href="{{ get_term_link($child_term) }}">{!! $child_term->name !!}</a>
           </li>

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -1,6 +1,6 @@
 @if(get_terms(['taxonomy' => $taxonomy]))
   <ul class="link-list">
-  @foreach(get_terms(['taxonomy' => $taxonomy, 'orderby' => 'order']) as $term)
+  @foreach(get_terms(['taxonomy' => $taxonomy]) as $term)
     @if(get_term_children($term->term_id, $taxonomy))
       <li>
         <hr class="is-style-thick has-grey-200-background-color" />
@@ -11,7 +11,7 @@
           <li class="link-list__item">
             <a href="{{ get_term_link($term) }}">{!! $term->name !!}</a>
           </li>
-          @foreach(get_terms(['taxonomy' => $taxonomy, 'parent' => $term->term_id, 'orderby' => 'name']) as $child_term)
+          @foreach(get_terms(['taxonomy' => $taxonomy, 'parent' => $term->term_id]) as $child_term)
           <li class="link-list__item">
             <a href="{{ get_term_link($child_term) }}">{!! $child_term->name !!}</a>
           </li>

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -35,7 +35,7 @@
                     <span class="supplementary-label" hidden> ({{ sprintf(__('and %d subtopics', 'coop-library'), count(get_term_children($term->term_id, $tax))) }})</span>
                     <span class="filter-disclosure-label" hidden>{{ sprintf(__('show %d subtopics for "%s"', 'coop-library'), count(get_term_children($term->term_id, $tax)), $term->name) }}</span>
                     <ul class="input-group input-group__descendant">
-                      @foreach(get_terms(['taxonomy' => $tax, 'parent' => $term->term_id, 'orderby' => 'name']) as $child_term)
+                      @foreach(get_terms(['taxonomy' => $tax, 'parent' => $term->term_id, 'orderby' => 'order']) as $child_term)
                       <li>
                         <input id="{{ $tax }}-{{ $child_term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $child_term->slug }}" {{
                         checked(

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -21,7 +21,7 @@
               <span class="button__label">{{ __('Deselect all', 'coop-library') }}<span class="screen-reader-text"> {{ $label }}</span></span>
             </button>
             <ul id="{{ $tax }}" class="input-group input-group__parent {{ $tax }}">
-              @foreach(get_terms(['taxonomy' => $tax]) as $term)
+              @foreach(get_terms(['taxonomy' => $tax, 'orderby' => 'order']) as $term)
                 @if(!$term->parent)
                 <li>
                   <input id="{{ $tax }}-{{ $term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $term->slug }}" {{

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -5,11 +5,12 @@
       <h2 class="h1 screen-reader-text">{{ __('Filters', 'coop-library' ) }}</h2>
       <div class="accordion accordion--filter-list">
         @foreach([
-          'lc_region' => __('Location of relevance', 'coop-library'),
           'lc_goal' => __('Goals', 'coop-library'),
           'lc_topic' => __('Topics', 'coop-library'),
-          'lc_format' => __('Format', 'coop-library'),
-          'lc_sector' => __('Sector', 'coop-library'),
+          'lc_coop_type' => __('Co-op Types', 'coop-library'),
+          'lc_sector' => __('Sectors', 'coop-library'),
+          'lc_region' => __('Locations', 'coop-library'),
+          'lc_format' => __('Formats', 'coop-library'),
         ] as $tax => $label)
         @if(get_terms($tax))
         <div class="accordion__pane">

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -13,7 +13,7 @@
           'lc_region' => __('Locations', 'coop-library'),
           'lc_format' => __('Formats', 'coop-library'),
         ] as $tax => $label)
-        @if(get_terms($tax))
+        @if(get_terms(['taxonomy' => $tax, 'orderby' => 'order']))
         <div class="accordion__pane">
           <p class="accordion__heading">{{ $label }}</p>
           <div class="accordion__content">
@@ -21,7 +21,7 @@
               <span class="button__label">{{ __('Deselect all', 'coop-library') }}<span class="screen-reader-text"> {{ $label }}</span></span>
             </button>
             <ul id="{{ $tax }}" class="input-group input-group__parent {{ $tax }}">
-              @foreach(get_terms($tax) as $term)
+              @foreach(get_terms(['taxonomy' => $tax, 'orderby' => 'order']) as $term)
                 @if(!$term->parent)
                 <li>
                   <input id="{{ $tax }}-{{ $term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $term->slug }}" {{
@@ -35,7 +35,7 @@
                     <span class="supplementary-label" hidden> ({{ sprintf(__('and %d subtopics', 'coop-library'), count(get_term_children($term->term_id, $tax))) }})</span>
                     <span class="filter-disclosure-label" hidden>{{ sprintf(__('show %d subtopics for "%s"', 'coop-library'), count(get_term_children($term->term_id, $tax)), $term->name) }}</span>
                     <ul class="input-group input-group__descendant">
-                      @foreach(get_terms(['taxonomy' => $tax, 'parent' => $term->term_id]) as $child_term)
+                      @foreach(get_terms(['taxonomy' => $tax, 'parent' => $term->term_id, 'orderby' => 'name']) as $child_term)
                       <li>
                         <input id="{{ $tax }}-{{ $child_term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $child_term->slug }}" {{
                         checked(

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -13,7 +13,7 @@
           'lc_region' => __('Locations', 'coop-library'),
           'lc_format' => __('Formats', 'coop-library'),
         ] as $tax => $label)
-        @if(get_terms(['taxonomy' => $tax, 'orderby' => 'order']))
+        @if(get_terms(['taxonomy' => $tax]))
         <div class="accordion__pane">
           <p class="accordion__heading">{{ $label }}</p>
           <div class="accordion__content">
@@ -21,7 +21,7 @@
               <span class="button__label">{{ __('Deselect all', 'coop-library') }}<span class="screen-reader-text"> {{ $label }}</span></span>
             </button>
             <ul id="{{ $tax }}" class="input-group input-group__parent {{ $tax }}">
-              @foreach(get_terms(['taxonomy' => $tax, 'orderby' => 'order']) as $term)
+              @foreach(get_terms(['taxonomy' => $tax]) as $term)
                 @if(!$term->parent)
                 <li>
                   <input id="{{ $tax }}-{{ $term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $term->slug }}" {{
@@ -35,7 +35,7 @@
                     <span class="supplementary-label" hidden> ({{ sprintf(__('and %d subtopics', 'coop-library'), count(get_term_children($term->term_id, $tax))) }})</span>
                     <span class="filter-disclosure-label" hidden>{{ sprintf(__('show %d subtopics for "%s"', 'coop-library'), count(get_term_children($term->term_id, $tax)), $term->name) }}</span>
                     <ul class="input-group input-group__descendant">
-                      @foreach(get_terms(['taxonomy' => $tax, 'parent' => $term->term_id, 'orderby' => 'order']) as $child_term)
+                      @foreach(get_terms(['taxonomy' => $tax, 'parent' => $term->term_id]) as $child_term)
                       <li>
                         <input id="{{ $tax }}-{{ $child_term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $child_term->slug }}" {{
                         checked(


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

With https://github.com/platform-coop-toolkit/coop-library-framework/pull/295 in place, terms should display sorted by numeric order, then name. This has the impact of allowing terms to be sorted numerically at the parent level (where an explicit numeric order has been set) while reverting to alphabetical order at the child level.

## Steps to test

1. Ensure that both this PR and https://github.com/platform-coop-toolkit/coop-library-framework/pull/295 are checked out.
2. Apply custom order to the top-level topics, as defined in #168.
3. Browse all resources.

**Expected behavior:** Topics are sorted by custom order at the parent level and alphabetically at the child level.

## Additional information

Not applicable.

## Related issues

- Depends on https://github.com/platform-coop-toolkit/coop-library-framework/pull/295.
- Resolves #168.
