### PR TITLE
fix: don't allow saved searches over limit (resolves #206)

### DIFF
--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -96,6 +96,14 @@ export default {
               const tags = document.querySelectorAll('.filters input:checked');
               let savedSearches = localStorage.getItem('saved-searches');
               savedSearches = savedSearches ? JSON.parse(savedSearches) : {};
+              if (Object.keys(savedSearches).length === 50) {
+                addNotification(
+                  __('Maximum number of saved searches reached', 'coop-library'),
+                  __('You have reached the maximum amount of saved searches (50). To save more, you must delete some saved searches.', 'coop-library'),
+                  'error'
+                );
+                return false;
+              }
               const now = Date.now();
               const term = document.querySelector('.filters input[name="s"]').value;
               const name = input ? input : sprintf(__('Saved search for “%s”', 'coop-library'), term);

--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -98,7 +98,7 @@ export default {
               savedSearches = savedSearches ? JSON.parse(savedSearches) : {};
               if (Object.keys(savedSearches).length === 50) {
                 addNotification(
-                  __('Maximum number of saved searches reached', 'coop-library'),
+                  __('Search not saved', 'coop-library'),
                   __('You have reached the maximum amount of saved searches (50). To save more, you must delete some saved searches.', 'coop-library'),
                   'error'
                 );


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes issue where users could save searches above the limit of 50.

## Steps to test

1. Save searches.

**Expected behavior:** Once user reaches 50 saved searches, they are warned and prevented from saving more.

## Additional information

Not applicable.

## Related issues

- Resolves #206.