### PR TITLE
feat: read language from metadata (resolves #129)

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -13,8 +13,14 @@ class App extends Controller
         return get_bloginfo('name');
     }
 
+    public function languages()
+    {
+        return get_language_list(pll_current_language('locale'));
+    }
+
     public function queriedResourceTerms()
     {
+        $langs = get_language_list(pll_current_language('locale'));
         $terms = [
             'language' => [],
             'lc_format' => [],
@@ -34,15 +40,10 @@ class App extends Controller
         }
         if (isset($_GET['language'])) {
             foreach ($_GET['language'] as $lang) {
-                $terms['language'][ $lang ] = $lang;
+                $terms['language'][ $lang ] = $langs[$lang];
             }
         }
         return $terms;
-    }
-
-    public function languages()
-    {
-        return get_language_list(pll_current_language('locale'));
     }
 
     public function currentLanguageName()

--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -28,8 +28,13 @@ class App extends Controller
         if ($wp_query->tax_query) {
             foreach ($wp_query->tax_query->queries as $value) {
                 foreach ($value['terms'] as $t) {
-                    $terms[$value['taxonomy']][$t] = get_term_by('slug', $t, $value['taxonomy']);
+                    $terms[$value['taxonomy']][$t] = get_term_by('slug', $t, $value['taxonomy'])->name;
                 }
+            }
+        }
+        if (isset($_GET['language'])) {
+            foreach ($_GET['language'] as $lang) {
+                $terms['language'][ $lang ] = $lang;
             }
         }
         return $terms;
@@ -334,6 +339,32 @@ class App extends Controller
     public static function sortUrl($order_by)
     {
         return add_query_arg('order_by', $order_by);
+    }
+
+    public static function getMetaValues($key = '', $type = 'post', $status = 'publish')
+    {
+        global $wpdb;
+
+        if (empty($key)) {
+            return;
+        }
+
+        $results = $wpdb->get_col(
+            $wpdb->prepare(
+                "
+            SELECT pm.meta_value FROM {$wpdb->postmeta} pm
+            LEFT JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+            WHERE pm.meta_key = %s
+            AND p.post_status = %s
+            AND p.post_type = %s
+        ",
+                $key,
+                $status,
+                $type
+            )
+        );
+
+        return array_unique($results);
     }
 
     public static function title()

--- a/app/Controllers/Partials/Resource.php
+++ b/app/Controllers/Partials/Resource.php
@@ -147,11 +147,9 @@ trait Resource
     {
         global $post;
 
-        if (function_exists('pll_get_post_language')) {
-            return pll_get_post_language($post->ID, $format);
+        if ($format === 'slug') {
+            return get_post_meta($post->ID, 'language', true);
         }
-
-        return 'en';
     }
 
     public static function getFormat()

--- a/app/filters.php
+++ b/app/filters.php
@@ -96,7 +96,7 @@ add_filter('comments_template', function ($comments_template) {
 add_filter('pre_get_posts', function ($query) {
     if (!is_admin()) {
         if ((is_post_type_archive('lc_resource') || is_tax()) && $query->is_main_query()) {
-            if (! empty($_GET['order_by'])) {
+            if (isset($_GET['order_by'])) {
                 switch ($_GET['order_by']) {
                     case 'published':
                         $query->set('meta_key', 'lc_resource_publication_date');
@@ -135,6 +135,18 @@ add_filter('pre_get_posts', function ($query) {
                         $query->set('orderby', 'date');
                         break;
                 }
+            }
+            if (isset($_GET['language'])) {
+                $meta_query = [
+                    'relation' => 'OR'
+                ];
+                foreach ($_GET['language'] as $lang) {
+                    $meta_query[] = [
+                        'key' => 'language',
+                        'value' => $lang,
+                    ];
+                }
+                $query->set('meta_query', $meta_query);
             }
             $query->set('posts_per_page', 12);
             $query->set('order', 'desc');

--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -111,7 +111,7 @@ export default {
               addNotification(
                 __('Search saved', 'coop-library'),
                 sprintf(
-                  __('You have successfully saved this search. You can save %d more. You can see this search in your <a href="%s">saved searches page</a>.', 'coop-library'),
+                  __('You have successfully saved this search. You can save %1$d more. You can see this search in your <a href="%2$s">saved searches page</a>.', 'coop-library'),
                   remaining,
                   CoopLibrary.savedSearchesLink
                 ),

--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -1,6 +1,7 @@
 /* global CoopLibrary */
 
 import addNotification from '../util/addNotification';
+import Cookies from 'cookies.js';
 import Pinecone from '@platform-coop-toolkit/pinecone';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -43,7 +44,22 @@ export default {
           headingSelector: '.accordion__heading',
         }
       );
+      const expandedAlready = document.querySelectorAll('.accordion__pane--expanded');
+      Array.prototype.forEach.call( expandedAlready, pane => {
+        pane.querySelector('.accordion__control').setAttribute('aria-expanded', true);
+      });
     } );
+
+    document.addEventListener('click', (event) => {
+      if (!event.target.matches('.accordion__control')) return;
+      const id = event.target.parentNode.id;
+      const expanded = 'true' == event.target.getAttribute('aria-expanded') || false;
+      if (expanded) {
+        Cookies.set('filters-expanded', id);
+      } else {
+        Cookies.remove('filters-expanded');
+      }
+    });
 
     const filterDisclosureLabels = document.querySelectorAll( '.filter-disclosure-label' );
 

--- a/resources/lang/coop-library.pot
+++ b/resources/lang/coop-library.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-26 10:01-0700\n"
+"POT-Creation-Date: 2020-03-09 15:58-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,42 +54,69 @@ msgstr ""
 msgid "Continued"
 msgstr ""
 
-#: app/setup.php:58
+#: app/setup.php:59
 msgid "Primary Navigation"
 msgstr ""
 
-#: app/setup.php:109
+#: app/setup.php:110
 msgid "Primary"
 msgstr ""
 
-#: app/setup.php:113
+#: app/setup.php:114
 msgid "Footer"
 msgstr ""
 
-#: app/Controllers/App.php:93
+#: app/Controllers/App.php:130
+msgid "&laquo; Previous"
+msgstr ""
+
+#: app/Controllers/App.php:131
+msgid "Next &raquo;"
+msgstr ""
+
+#: app/Controllers/App.php:238
+msgid "&hellip;"
+msgstr ""
+
+#: app/Controllers/App.php:300
+msgid "previous"
+msgstr ""
+
+#: app/Controllers/App.php:304
+msgid "next"
+msgstr ""
+
+#: app/Controllers/App.php:306
+msgid "Resources navigation"
+msgstr ""
+
+#: app/Controllers/App.php:307
+msgid "resources"
+msgstr ""
+
+#: app/Controllers/App.php:375
 msgid ""
 "<span class=\"pc-ff--sans pc-fw--normal\">Platform Co-op</span><br /"
 ">Resource Library"
 msgstr ""
 
-#: app/Controllers/App.php:101
+#: app/Controllers/App.php:383
 msgid "Latest Posts"
 msgstr ""
 
-#: app/Controllers/App.php:105
+#: app/Controllers/App.php:387
+msgid "Search results"
+msgstr ""
+
+#: app/Controllers/App.php:391
 msgid "Browse all"
 msgstr ""
 
-#: app/Controllers/App.php:109
-#, php-format
-msgid "Search Results for %s"
-msgstr ""
-
-#: app/Controllers/App.php:112
+#: app/Controllers/App.php:395
 msgid "Not Found"
 msgstr ""
 
-#: app/Controllers/App.php:122
+#: app/Controllers/App.php:406
 msgid "Home"
 msgstr ""
 
@@ -97,12 +124,10 @@ msgstr ""
 msgid "Sorry, no results were found."
 msgstr ""
 
-#: resources/views/index.blade.php:26 resources/views/search.blade.php:26
-msgid "previous resources"
-msgstr ""
-
-#: resources/views/index.blade.php:27 resources/views/search.blade.php:27
-msgid "next resources"
+#: resources/views/index.blade.php:10 resources/views/404.blade.php:10
+#: resources/views/search.blade.php:10
+#: resources/views/partials/content-front-page.blade.php:2
+msgid "Search resource name, publisher, or topic…"
 msgstr ""
 
 #: resources/views/404.blade.php:8
@@ -110,20 +135,38 @@ msgid "Sorry, but the page you were trying to view does not exist."
 msgstr ""
 
 #: resources/views/partials/header.blade.php:6
-#: resources/views/partials/search-form.blade.php:7
+#: resources/views/partials/search-form.blade.php:8
 msgid "Search"
 msgstr ""
 
+#: resources/views/partials/header.blade.php:28
+msgid "Explore"
+msgstr ""
+
+#: resources/views/partials/current-filters.blade.php:3
+msgid "Showing %1$s of %2$s resources for:"
+msgstr ""
+
+#: resources/views/partials/current-filters.blade.php:5
+#: resources/assets/scripts/routes/saved-searches.js:50
+msgid "Search term"
+msgstr ""
+
 #: resources/views/partials/current-filters.blade.php:9
+msgid "Applied filters"
+msgstr ""
+
+#: resources/views/partials/current-filters.blade.php:14
 #: resources/views/partials/content-page-favorites.blade.php:8
+#: resources/assets/scripts/routes/saved-searches.js:55
 msgid "Remove"
 msgstr ""
 
-#: resources/views/partials/current-filters.blade.php:9
+#: resources/views/partials/current-filters.blade.php:14
 msgid "from current filters"
 msgstr ""
 
-#: resources/views/partials/current-filters.blade.php:15
+#: resources/views/partials/current-filters.blade.php:19
 msgid "Clear all"
 msgstr ""
 
@@ -141,6 +184,10 @@ msgstr ""
 
 #: resources/views/partials/comments.blade.php:33
 msgid "Comments are closed."
+msgstr ""
+
+#: resources/views/partials/save-search.blade.php:3
+msgid "Save my search"
 msgstr ""
 
 #: resources/views/partials/content-page.blade.php:2
@@ -173,52 +220,84 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:5
+#: resources/views/partials/filters.blade.php:9
 msgid "Close"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:6
+#: resources/views/partials/filters.blade.php:10
 msgid "Filters"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:9
-msgid "Location of relevance"
-msgstr ""
-
-#: resources/views/partials/filters.blade.php:10
+#: resources/views/partials/filters.blade.php:13
 #: resources/views/partials/content-front-page.blade.php:10
 msgid "Goals"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:11
+#: resources/views/partials/filters.blade.php:14
 #: resources/views/partials/content-front-page.blade.php:9
 msgid "Topics"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:12
-msgid "Format"
+#: resources/views/partials/filters.blade.php:15
+msgid "Co-op Types"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:13
-msgid "Sector"
+#: resources/views/partials/filters.blade.php:16
+#: resources/views/partials/content-front-page.blade.php:11
+msgid "Sectors"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:20
+#: resources/views/partials/filters.blade.php:17
+msgid "Locations"
+msgstr ""
+
+#: resources/views/partials/filters.blade.php:18
+#: resources/views/partials/content-front-page.blade.php:12
+msgid "Formats"
+msgstr ""
+
+#: resources/views/partials/filters.blade.php:25
+#: resources/views/partials/filters.blade.php:67
 msgid "Deselect all"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:34
+#: resources/views/partials/filters.blade.php:39
 #, python-format
 msgid "and %d subtopics"
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:35
-#, python-format
-msgid "show %d subtopics for \"%s\""
+#: resources/views/partials/filters.blade.php:40
+msgid "show %1$d subtopics for \"%2$s\""
 msgstr ""
 
-#: resources/views/partials/filters.blade.php:60
+#: resources/views/partials/filters.blade.php:64
+msgid "Languages"
+msgstr ""
+
+#: resources/views/partials/filters.blade.php:67
+msgid "languages"
+msgstr ""
+
+#: resources/views/partials/filters.blade.php:81
 msgid "Apply Filters"
+msgstr ""
+
+#: resources/views/partials/content-page-saved-searches.blade.php:3
+#: resources/views/partials/content-page-favorites.blade.php:2
+msgid "Remove all"
+msgstr ""
+
+#: resources/views/partials/content-page-saved-searches.blade.php:3
+msgid "saved searches"
+msgstr ""
+
+#: resources/views/partials/content-page-saved-searches.blade.php:8
+msgid "You have no saved searches."
+msgstr ""
+
+#: resources/views/partials/content-page-saved-searches.blade.php:9
+#, python-format
+msgid "Search or <a href=\"%s\">browse</a> for resources to save your search."
 msgstr ""
 
 #: resources/views/partials/content-term-list.blade.php:29
@@ -226,20 +305,8 @@ msgstr ""
 msgid "No %s found."
 msgstr ""
 
-#: resources/views/partials/content-front-page.blade.php:2
-msgid "Search resource name, publisher, or topic…"
-msgstr ""
-
 #: resources/views/partials/content-front-page.blade.php:6
 msgid "Browse by…"
-msgstr ""
-
-#: resources/views/partials/content-front-page.blade.php:11
-msgid "Sectors"
-msgstr ""
-
-#: resources/views/partials/content-front-page.blade.php:12
-msgid "Formats"
 msgstr ""
 
 #: resources/views/partials/content-front-page.blade.php:17
@@ -279,23 +346,23 @@ msgstr ""
 msgid "language"
 msgstr ""
 
-#: resources/views/partials/content-lc_resource.blade.php:31
+#: resources/views/partials/content-lc_resource.blade.php:33
 #: resources/views/partials/content-single-lc_resource.blade.php:26
 msgid "date published"
 msgstr ""
 
-#: resources/views/partials/content-lc_resource.blade.php:42
+#: resources/views/partials/content-lc_resource.blade.php:44
 #, python-format
 msgid "+%d more"
 msgstr ""
 
-#: resources/views/partials/content-lc_resource.blade.php:47
+#: resources/views/partials/content-lc_resource.blade.php:49
 #: resources/views/partials/content-single-lc_resource.blade.php:110
 #, python-format
 msgid "Added %s"
 msgstr ""
 
-#: resources/views/partials/content-lc_resource.blade.php:51
+#: resources/views/partials/content-lc_resource.blade.php:53
 msgid "Favorited"
 msgstr ""
 
@@ -359,10 +426,6 @@ msgstr ""
 
 #: resources/views/partials/content-single-lc_resource.blade.php:101
 msgid "View on the Internet Archive"
-msgstr ""
-
-#: resources/views/partials/content-page-favorites.blade.php:2
-msgid "Remove all"
 msgstr ""
 
 #: resources/views/partials/content-page-favorites.blade.php:2
@@ -434,6 +497,138 @@ msgstr ""
 msgid "The resource could not be added to your favorites."
 msgstr ""
 
+#: resources/assets/scripts/routes/saved-searches.js:15
+#: resources/assets/scripts/routes/archive.js:81
+msgid "Maximum number of saved searches reached"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:16
+msgid ""
+"You have reached the maximum amount of saved searches (50). To save more, "
+"you must delete some saved searches."
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:35
+msgid "Tags"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:46
+msgid "Show details"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:72
+msgid "Confirm remove saved searches"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:73
+msgid "Are you sure you want to remove all of your saved searches?"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:74
+#: resources/assets/scripts/routes/saved-searches.js:93
+#: resources/assets/scripts/routes/favorites.js:20
+#: resources/assets/scripts/routes/favorites.js:50
+msgid "Yes, remove"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:75
+#: resources/assets/scripts/routes/saved-searches.js:94
+#: resources/assets/scripts/routes/favorites.js:21
+#: resources/assets/scripts/routes/favorites.js:51
+msgid "No, don&rsquo;t remove"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:81
+msgid "Saved searches removed"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:81
+msgid "Your saved searches have been removed."
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:83
+msgid "Saved searches not removed"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:83
+msgid "Your saved searches could not be removed."
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:91
+msgid "Confirm remove saved search"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:92
+msgid "Are you sure you want to remove this saved search?"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:107
+msgid "Saved search removed"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:107
+msgid "Your saved search has been removed."
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:109
+msgid "Saved search not removed"
+msgstr ""
+
+#: resources/assets/scripts/routes/saved-searches.js:109
+msgid "Your saved search could not be removed"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:82
+#, python-format
+msgid ""
+"You have reached the maximum amount of saved searches (50). To save more, "
+"you must <a href=\"%s\">delete some saved searches</a>."
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:88
+msgid "Save search"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:89
+msgid ""
+"To save your search, please give it a name so you can identify it later."
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:91
+msgid "Name of saved search:"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:92
+msgid "Save"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:93
+msgid "Don&rsquo;t save"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:101
+#, python-format
+msgid "Saved search for “%s”"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:112
+msgid "Search saved"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:114
+msgid ""
+"You have successfully saved this search. You can save %1$d more. You can see "
+"this search in your <a href=\"%2$s\">saved searches page</a>."
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:121
+msgid "Search not saved"
+msgstr ""
+
+#: resources/assets/scripts/routes/archive.js:121
+msgid "Your search could not be saved."
+msgstr ""
+
 #: resources/assets/scripts/routes/favorites.js:12
 msgid "Favorites not supported"
 msgstr ""
@@ -450,16 +645,6 @@ msgstr ""
 
 #: resources/assets/scripts/routes/favorites.js:19
 msgid "Are you sure you want to remove all resources from your favorites?"
-msgstr ""
-
-#: resources/assets/scripts/routes/favorites.js:20
-#: resources/assets/scripts/routes/favorites.js:50
-msgid "Yes, remove"
-msgstr ""
-
-#: resources/assets/scripts/routes/favorites.js:21
-#: resources/assets/scripts/routes/favorites.js:51
-msgid "No, don&rsquo;t remove"
 msgstr ""
 
 #: resources/assets/scripts/routes/favorites.js:35

--- a/resources/views/partials/content-lc_resource.blade.php
+++ b/resources/views/partials/content-lc_resource.blade.php
@@ -25,6 +25,8 @@
       @svg('info', 'icon--info', ['focusable' => 'false', 'aria-hidden' => 'true'])
       @if($current_language !== Archive::getLanguage())
       <span class="card__language"><span class="screen-reader-text">{{ __('language', 'coop-library') }}: </span>{{ $languages[Archive::getLanguage()] }}</span>
+      @endif
+      @if($current_language !== Archive::getLanguage() && Archive::getPublicationDate())
       <span class="separator">.</span>
       @endif
       @if(Archive::getPublicationDate())

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -9,13 +9,11 @@
     <h2 class="h4">{{ __('Applied filters', 'coop-library') }}</h2>
     <ul class="tags">
       @foreach($queried_resource_terms as $taxonomy => $terms)
-        @if($taxonomy !== 'language')
-          @foreach($terms as $term)
-          <li class="tag">
-            <button class="button button--tag-button" data-checkbox="{{ $term->taxonomy }}-{{ $term->slug }}"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{!! $term->name !!}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
-          </li>
-          @endforeach
-        @endif
+        @foreach($terms as $term => $name)
+        <li class="tag">
+          <button class="button button--tag-button" data-checkbox="{{ $taxonomy }}-{{ $term }}"><span class="screen-reader-text">{{ __('Remove', 'coop-library') }} </span>{!! $name !!}<span class="screen-reader-text"> {{ __('from current filters', 'coop-library') }}</span> @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
+        </li>
+        @endforeach
       @endforeach
     </ul>
   <p><a href="{{ get_post_type_archive_link('lc_resource') }}">{{ __('Clear all', 'coop-library') }}</a></p>

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -37,7 +37,7 @@
                   <label for="{{ $tax }}-{{ $term->slug }}">{!! $term->name !!}</label>
                   @if(get_term_children($term->term_id, $tax))
                     <span class="supplementary-label" hidden> ({{ sprintf(__('and %d subtopics', 'coop-library'), count(get_term_children($term->term_id, $tax))) }})</span>
-                    <span class="filter-disclosure-label" hidden>{{ sprintf(__('show %d subtopics for "%s"', 'coop-library'), count(get_term_children($term->term_id, $tax)), $term->name) }}</span>
+                    <span class="filter-disclosure-label" hidden>{{ sprintf(__('show %1$d subtopics for "%2$s"', 'coop-library'), count(get_term_children($term->term_id, $tax)), $term->name) }}</span>
                     <ul class="input-group input-group__descendant">
                       @foreach(get_terms(['taxonomy' => $tax, 'lang' => '', 'parent' => $term->term_id]) as $child_term)
                       <li>

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -18,7 +18,7 @@
           'lc_format' => __('Formats', 'coop-library'),
         ] as $tax => $label)
         @if(get_terms(['taxonomy' => $tax, 'lang' => '']))
-        <div class="accordion__pane">
+        <div class="accordion__pane @if(isset($_COOKIE['filters-expanded']) && $_COOKIE['filters-expanded'] === "accordion-$tax"){{ ' accordion__pane--expanded' }}@endif" id="accordion-{{ $tax }}">
           <p class="accordion__heading">{{ $label }}</p>
           <div class="accordion__content">
             <button id="deselect-{{ $tax }}" type="button" class="button button--borderless">
@@ -60,7 +60,7 @@
         </div>
         @endif
         @endforeach
-        <div class="accordion__pane">
+        <div class="accordion__pane @if(isset($_COOKIE['filters-expanded']) && $_COOKIE['filters-expanded'] === "accordion-language"){{ ' accordion__pane--expanded' }}@endif" id="accordion-language">
           <p class="accordion__heading">{{ __('Languages', 'coop-library') }}</p>
           <div class="accordion__content">
             <button id="deselect-language" type="button" class="button button--borderless">
@@ -69,7 +69,7 @@
             <ul id="language" class="input-group input-group__parent language">
               @foreach(App::getMetaValues('language', 'lc_resource') as $language)
               <li>
-                <input id="language-{{ $language }}" name="language[]" type="checkbox" value="{{ $language }}" />
+                <input id="language-{{ $language }}" name="language[]" type="checkbox" value="{{ $language }}" {{ checked(in_array($language, array_keys($queried_resource_terms['language']))) }} />
                 <label for="language-{{ $language }}">{!! $languages[$language] !!}</label>
               </li>
               @endforeach

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -60,6 +60,22 @@
         </div>
         @endif
         @endforeach
+        <div class="accordion__pane">
+          <p class="accordion__heading">{{ __('Language', 'coop-library') }}</p>
+          <div class="accordion__content">
+            <button id="deselect-language" type="button" class="button button--borderless">
+              <span class="button__label">{{ __('Deselect all', 'coop-library') }}<span class="screen-reader-text"> {{ __('languages', 'coop-library') }}</span></span>
+            </button>
+            <ul id="language" class="input-group input-group__parent language">
+              @foreach(App::getMetaValues('language', 'lc_resource') as $language)
+              <li>
+                <input id="language-{{ $language }}" name="language[]" type="checkbox" value="{{ $language }}" />
+                <label for="language-{{ $language }}">{!! $language !!}</label>
+              </li>
+              @endforeach
+            </ul>
+          </div>
+        </div>
       </div>
       <div class="input-group">
         <button id="apply-filters" class="button" type="submit">{{ __('Apply Filters', 'coop-library') }}</button>

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -61,7 +61,7 @@
         @endif
         @endforeach
         <div class="accordion__pane">
-          <p class="accordion__heading">{{ __('Language', 'coop-library') }}</p>
+          <p class="accordion__heading">{{ __('Languages', 'coop-library') }}</p>
           <div class="accordion__content">
             <button id="deselect-language" type="button" class="button button--borderless">
               <span class="button__label">{{ __('Deselect all', 'coop-library') }}<span class="screen-reader-text"> {{ __('languages', 'coop-library') }}</span></span>
@@ -70,7 +70,7 @@
               @foreach(App::getMetaValues('language', 'lc_resource') as $language)
               <li>
                 <input id="language-{{ $language }}" name="language[]" type="checkbox" value="{{ $language }}" />
-                <label for="language-{{ $language }}">{!! $language !!}</label>
+                <label for="language-{{ $language }}">{!! $languages[$language] !!}</label>
               </li>
               @endforeach
             </ul>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds support for resource languages stored in metadata (see https://github.com/platform-coop-toolkit/coop-library-framework/pull/316) and the ability to filter resources by language. It also preserves accordion status on filter application, resolving #129.

## Steps to test

1. Ensure that your library is up to date with https://github.com/platform-coop-toolkit/coop-library-framework/pull/316 and that language metadata has been converted.
2. Visit the Resources page.

**Expected behavior:** Resources in all languages are shown, and they can be filtered by language.

## Additional information

Not applicable.

## Related issues

- Depends on https://github.com/platform-coop-toolkit/coop-library-framework/pull/316.
- Resolves #129.