### PR TITLE
feat: add content to empty favorites page

### DIFF
--- a/resources/assets/styles/layouts/_pages.scss
+++ b/resources/assets/styles/layouts/_pages.scss
@@ -17,6 +17,10 @@
   }
 }
 
+#favorites + .no-favorites {
+  display: none;
+}
+
 #saved-searches:not(:empty) + * {
   display: none;
 }

--- a/resources/views/partials/content-page-favorites.blade.php
+++ b/resources/views/partials/content-page-favorites.blade.php
@@ -11,3 +11,7 @@
   </ul>
 </div>
 @endif
+<div class="no-favorites">
+  <p class="h2">{{__('You have no favorites.', 'coop-library') }}</p>
+  <p>{!! sprintf(__('Search or <a href="%s">browse</a> for resources to favorite them.', 'coop-library'), get_post_type_archive_link('lc_resource')) !!}</p>
+</div>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Implements designs from XD for the content of the Favorites page when no favorites have been added.

## Steps to test

1. Visit Favorites page.
2. Delete favorites, if any.

**Expected behavior:** Confirm that the expected message appears.

## Additional information

Not applicable.

## Related issues

Not applicable.
