### PR TITLE
fix: use different text for screen reader button labels

### DIFF
--- a/resources/views/partials/content-page-favorites.blade.php
+++ b/resources/views/partials/content-page-favorites.blade.php
@@ -1,5 +1,5 @@
 @if($favorites->have_posts())
-<div class="align-right"><button id="remove-all" class="button button--borderless button--destructive">@svg('delete', 'icon--delete', ['focusable' => 'false', 'aria-hidden' => 'true']) {{ __('Remove all', 'coop-library') }}<span class="screen-reader-text"> {{ __('favorites', 'coop-library') }}</span></button></div>
+<div class="align-right"><button id="remove-all" class="button button--borderless button--destructive">@svg('delete', 'icon--delete', ['focusable' => 'false', 'aria-hidden' => 'true']) <span aria-hidden="true">{{ __('Remove all', 'coop-library') }}</span><span class="screen-reader-text">{{ __('Remove all favorites', 'coop-library') }}</span></button></div>
 <div id="favorites" class="resource-list">
   <ul class="cards">
     @while ($favorites->have_posts()) @php $favorites->the_post() @endphp

--- a/resources/views/partials/content-page-saved-searches.blade.php
+++ b/resources/views/partials/content-page-saved-searches.blade.php
@@ -1,6 +1,6 @@
 <div class="align-right" hidden>
   <button id="remove-all" class="button button--borderless button--destructive">
-    @svg('delete', 'icon--delete', ['focusable' => 'false', 'aria-hidden' => 'true']) {{ __('Remove all', 'coop-library') }}​​&nbsp;<span class="screen-reader-text">{{ __('saved searches', 'coop-library') }}</span>
+    @svg('delete', 'icon--delete', ['focusable' => 'false', 'aria-hidden' => 'true']) <span aria-hidden="true">{{ __('Remove all', 'coop-library') }}</span>​​<span class="screen-reader-text">{{ __('Remove all saved searches', 'coop-library') }}</span>
   </button>
 </div>
 <div id="saved-searches"></div>

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -1,5 +1,29 @@
 @if(isset($_GET['s']) || $found_posts < App::totalPosts('lc_resource'))
 <div class="current-filters">
+  @php
+  global $wpdb;
+                        $args = [
+                            'post_type' => 'lc_resource',
+                            'show_date' => false,
+                            'days'    => 30,
+                        ];
+                        $start_date = gmdate('Y-m-d', strtotime("-{$args['days']} days"));
+                        $end_date   = gmdate('Y-m-d', strtotime('tomorrow midnight'));
+                        $sql        = $wpdb->prepare("SELECT p.id, SUM(visitors) As visitors, SUM(pageviews) AS pageviews FROM {$wpdb->prefix}koko_analytics_post_stats s JOIN {$wpdb->posts} p ON s.id = p.id WHERE s.date >= %s AND s.date <= %s AND p.post_type = %s AND p.post_status = 'publish' GROUP BY s.id ORDER BY pageviews DESC", [$start_date, $end_date, $args['post_type']]); // @codingStandardsIgnoreLine
+                        $results    = $wpdb->get_results($sql);
+                        $viewed_ids = ( ! empty($results) ) ? wp_list_pluck($results, 'id') : [];
+                        $unviewed_ids = get_posts([
+                            'orderby' => 'date',
+                            'order' => 'desc',
+                            'post_type' => 'lc_resource',
+                            'post__not_in' => $viewed_ids,
+                            'posts_per_page' => -1,
+                            'fields' => 'ids'
+                        ]);
+                        $ids = array_merge($viewed_ids + $unviewed_ids);
+                        echo count($viewed_ids);
+                        echo count($unviewed_ids);
+  @endphp
   <p class="h3">{{ sprintf(__('Showing %1$s of %2$s resources for:', 'coop-library'), $found_posts, App::totalPosts('lc_resource')) }}</p>
   @if(isset($_GET['s']))
   <h2 class="h4">{{ __('Search term', 'coop-library') }}</h2>

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -22,7 +22,7 @@
           <p class="accordion__heading">{{ $label }}</p>
           <div class="accordion__content">
             <button id="deselect-{{ $tax }}" type="button" class="button button--borderless">
-              <span class="button__label">{{ __('Deselect all', 'coop-library') }}<span class="screen-reader-text"> {{ $label }}</span></span>
+              <span class="button__label"><span aria-hidden="true">{{ __('Deselect all', 'coop-library') }}</span><span class="screen-reader-text">{{ sprintf(__('Deselect all %s', 'coop-library'), $label) }}</span></span>
             </button>
             <ul id="{{ $tax }}" class="input-group input-group__parent {{ $tax }}">
               @foreach(get_terms(['taxonomy' => $tax, 'lang' => '', 'orderby' => 'order']) as $term)


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Resolves #208.

## Steps to test

1. Test "Remove all" (favorites), "Remove all" (saved searches), and "Deselect all" (filters) buttons in screen readers.

**Expected behavior:** Screen readers should announce expanded labels for these buttons.

## Additional information

Not applicable.

## Related issues

- Resolves #208.