### PR TITLE
fix: improve screen reader behaviour (fixes #131, fixes #200)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3121,6 +3121,30 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wordpress/a11y": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.7.0.tgz",
+      "integrity": "sha512-slmpj1Dyb8oGkDRkmfkvR/KOvRMTvRFuc/yMk7omuNspj4MsLimKhpQnu16NycelC6IGg+Rzp/6ziYIAMi/1sw==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "@wordpress/dom-ready": "^2.7.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
+    },
     "@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.5.0.tgz",
@@ -4075,6 +4099,29 @@
         "json2php": "^0.0.4",
         "webpack": "^4.8.3",
         "webpack-sources": "^1.3.0"
+      }
+    },
+    "@wordpress/dom-ready": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.7.0.tgz",
+      "integrity": "sha512-YTx/M3hpF4hJx5xFE5eECUalruIl/xvW8mJaqDRqCL22ktVDpWwyUtQkHtiVkNi2B8lYln8y57CB4q+7R3xIwg==",
+      "requires": {
+        "@babel/runtime": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "@wordpress/element": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@platform-coop-toolkit/pinecone": "^1.0.0-alpha.11",
+    "@wordpress/a11y": "^2.7.0",
     "cookies.js": "^2.1.15"
   },
   "devDependencies": {

--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -4,6 +4,7 @@ import addNotification from '../util/addNotification';
 import Cookies from 'cookies.js';
 import Pinecone from '@platform-coop-toolkit/pinecone';
 import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 export default {
   init() {
@@ -20,6 +21,11 @@ export default {
     if ( 0 < deselectButtons.length ) {
       Array.prototype.forEach.call( deselectButtons, btn => {
         new Pinecone.DeselectAll( btn );
+        const filterGroup = btn.parentNode.parentNode;
+        const filterGroupLabel = filterGroup.firstElementChild.textContent;
+        btn.onclick = () => {
+          speak(sprintf(__('All %s have been deselected', 'coop-library'), filterGroupLabel));
+        }
       } );
     }
 

--- a/resources/assets/scripts/util/addNotification.js
+++ b/resources/assets/scripts/util/addNotification.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Add a notification.
@@ -26,7 +27,7 @@ export default (title, content, type) => {
   }
 
   const alert = `
-    <div class="notification notification--${type}" role="alert">
+    <div class="notification notification--${type}">
       <button class="button button--borderless"><svg class="icon icon--close" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path id="close" d="m11.41 10 4.3-4.29a1 1 0 1 0 -1.42-1.42l-4.29 4.3-4.29-4.3a1 1 0 0 0 -1.42 1.42l4.3 4.29-4.3 4.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l4.29-4.3 4.29 4.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z" fill="currentColor"/></svg>
       <span class="screen-reader-text">${__('Close notification', 'coop-library')}</span></button>
       <p class="notification__title">${icon} ${title}</p>
@@ -34,8 +35,12 @@ export default (title, content, type) => {
     </div>
   `;
 
+  speak(content, 'assertive');
+
   if (pageHeader.nextElementSibling.classList.contains('notification')) {
     pageHeader.nextElementSibling.parentNode.removeChild(pageHeader.nextElementSibling);
   }
   pageHeader.insertAdjacentHTML('afterend', alert);
+
+
 };


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds screen reader feedback when a "Deselect all" button is clicked in the filter list. Announces notifications when they are added to the DOM.

## Steps to test

1. Enable a screen reader (NVDA or VoiceOver).
2. Check some topics on the Browse All page's filter list.
3. Click the "Deselect all" button under topics.
4. Test all behaviours which display notifications (saving/removing saved searches, saving/removing favorites).

**Expected behavior:** "All topics have been deselected" is announced to screen reader users.

## Additional information

Implemented using the [@wordpress/a11y](https://www.npmjs.com/package/@wordpress/a11y) "speak" utility.

## Related issues

- Resolves #131.
- Resolves #200.
