### PR TITLE
feat: announce filters once applied (resolves #130)

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -68,6 +68,25 @@ class App extends Controller
         return $terms;
     }
 
+    public function filterCount()
+    {
+        $count = 0;
+        global $wp_query;
+        if ($wp_query->tax_query) {
+            foreach ($wp_query->tax_query->queries as $value) {
+                foreach ($value['terms'] as $t) {
+                    $count++;
+                }
+            }
+        }
+        if (isset($_GET['language'])) {
+            foreach ($_GET['language'] as $lang) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
     public function availableLanguages()
     {
         if (function_exists('pll_the_languages') && function_exists('pll_current_language')) {

--- a/app/filters.php
+++ b/app/filters.php
@@ -13,9 +13,8 @@ add_filter('body_class', function (array $classes) {
         }
     }
 
-    /** Add class if sidebar is active */
-    if (display_sidebar()) {
-        $classes[] = 'sidebar-primary';
+    if (isset($_GET['filtered']) && $_GET['filtered'] === '1') {
+        $classes[] = 'filtered';
     }
 
     /** Clean up class names for custom templates */

--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -3,7 +3,7 @@
 import addNotification from '../util/addNotification';
 import Cookies from 'cookies.js';
 import Pinecone from '@platform-coop-toolkit/pinecone';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 
 export default {
@@ -12,6 +12,15 @@ export default {
     const filterContainer = document.querySelector( '.filters' );
     const showFilters = document.querySelector( '#show-filters' );
     const hideFilters = document.querySelector( '#hide-filters' );
+
+    if (document.body.classList.contains('filtered')) {
+      const currentFilterCount = document.body.dataset.filters;
+      if ( currentFilterCount ) {
+        setTimeout(function() {
+          speak(sprintf(_n('%s filter applied. Resource list updated.', '%s filters applied. Resource list updated.', parseInt(currentFilterCount), 'coop-library'), currentFilterCount), 'assertive');
+        }, 1000);
+      }
+    }
 
     if ( showFilters && hideFilters && filterContainer ) {
       new Pinecone.FilterList( filterContainer, showFilters, hideFilters );

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,7 +1,11 @@
 <!doctype html>
 <html class="no-js" {!! get_language_attributes() !!}>
   @include('partials.head')
-  <body @php body_class() @endphp>
+  <body @php body_class() @endphp
+  @if($filter_count)
+  data-filters="{{ $filter_count }}"
+  @endif
+  >
     @php do_action('get_header') @endphp
     @include('partials.header')
     <div class="wrap container" role="document">

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -1,6 +1,7 @@
 <div class="filter-wrapper">
   <button type="button" class="button button--borderless" id="show-filters">@svg('filter', 'icon--filter', ['focusable' => 'false', 'aria-hidden' => 'true']) {{ __('Filter', 'coop-library' ) }}</button>
   <form name="filters" class="filters" action="{{ (isset($_GET['s'])) ? home_url('/') : get_post_type_archive_link('lc_resource') }}">
+      <input type="hidden" name="filtered" value="1" />
       @if(isset($_GET['s']))
       <input type="hidden" name="s" value="{{ $_GET['s'] }}" />
       <input type="hidden" name="post_type" value="lc_resource" />


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR adds screen reader feedback after applying filters.

## Steps to test

1. Enable a screen reader.
2. Visit the resource page.
3. Apply filters and submit.

**Expected behavior:** Screen reader announces: 

> `<n>` filter(s) applied. Resource list updated.

## Additional information

Not applicable.

## Related issues

- Resolves #130.
