### PR TITLE
fix: language filtering (resolves #237)

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -44,7 +44,7 @@ class App extends Controller
     {
         $langs = get_language_list(pll_current_language('locale'));
         $terms = [
-            'language' => [],
+            'resource_language' => [],
             'lc_format' => [],
             'lc_goal' => [],
             'lc_region' => [],
@@ -55,14 +55,16 @@ class App extends Controller
         global $wp_query;
         if ($wp_query->tax_query) {
             foreach ($wp_query->tax_query->queries as $value) {
-                foreach ($value['terms'] as $t) {
-                    $terms[$value['taxonomy']][$t] = get_term_by('slug', $t, $value['taxonomy'])->name;
+                if ($value['taxonomy'] !== 'language') {
+                    foreach ($value['terms'] as $t) {
+                        $terms[$value['taxonomy']][$t] = get_term_by('slug', $t, $value['taxonomy'])->name;
+                    }
                 }
             }
         }
-        if (isset($_GET['language'])) {
-            foreach ($_GET['language'] as $lang) {
-                $terms['language'][ $lang ] = $langs[$lang];
+        if (isset($_GET['resource_language'])) {
+            foreach ($_GET['resource_language'] as $lang) {
+                $terms['resource_language'][ $lang ] = $langs[$lang];
             }
         }
         return $terms;
@@ -116,7 +118,7 @@ class App extends Controller
         return 'en';
     }
 
-    public function foundPosts()
+    public function foundPosts($lang = 'en')
     {
         global $wp_query;
         return $wp_query->found_posts;
@@ -374,10 +376,16 @@ class App extends Controller
         return $navigation;
     }
 
-    public static function totalPosts($post_type = null)
+    public static function totalPosts($post_type = null, $lang = 'en')
     {
         if ($post_type) {
-            return wp_count_posts($post_type)->publish;
+            $q = new \WP_Query([
+                'post_type' => $post_type,
+                'post_status' => 'publish',
+                'lang' => $lang,
+                'fields' => 'ids'
+            ]);
+            return $q->found_posts;
         }
 
         return 0;

--- a/app/Controllers/FrontPage.php
+++ b/app/Controllers/FrontPage.php
@@ -27,7 +27,6 @@ class FrontPage extends Controller
             'post__not_in' => $viewed_ids,
             'posts_per_page' => 4,
             'fields' => 'ids',
-            'lang' => '',
         ]);
         $ids = array_merge($viewed_ids + $unviewed_ids);
 
@@ -48,7 +47,6 @@ class FrontPage extends Controller
             'orderby' => ['meta_value', 'date'],
             'posts_per_page' => 4,
             'order' => 'desc',
-            'lang' => '',
         ]);
     }
 }

--- a/app/Controllers/FrontPage.php
+++ b/app/Controllers/FrontPage.php
@@ -35,7 +35,6 @@ class FrontPage extends Controller
             'post__in' => $ids,
             'orderby' => 'post__in',
             'posts_per_page' => 4,
-            'lang' => '',
         ]);
     }
 

--- a/app/filters.php
+++ b/app/filters.php
@@ -136,11 +136,11 @@ add_filter('pre_get_posts', function ($query) {
                         break;
                 }
             }
-            if (isset($_GET['language'])) {
+            if (isset($_GET['resource_language'])) {
                 $meta_query = [
                     'relation' => 'OR'
                 ];
-                foreach ($_GET['language'] as $lang) {
+                foreach ($_GET['resource_language'] as $lang) {
                     $meta_query[] = [
                         'key' => 'language',
                         'value' => $lang,
@@ -150,7 +150,6 @@ add_filter('pre_get_posts', function ($query) {
             }
             $query->set('posts_per_page', 12);
             $query->set('order', 'desc');
-            $query->set('lang', '');
         }
     }
 });

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -1,6 +1,6 @@
-@if(isset($_GET['s']) || $found_posts < App::totalPosts('lc_resource'))
+@if(isset($_GET['s']) || $found_posts < App::totalPosts('lc_resource', $current_language))
 <div class="current-filters">
-  <p class="h3">{{ sprintf(__('Showing %1$s of %2$s resources for:', 'coop-library'), $found_posts, App::totalPosts('lc_resource')) }}</p>
+  <p class="h3">{{ sprintf(__('Showing %1$s of %2$s resources for:', 'coop-library'), $found_posts, App::totalPosts('lc_resource', $current_language)) }}</p>
   @if(isset($_GET['s']))
   <h2 class="h4">{{ __('Search term', 'coop-library') }}</h2>
   <p>&ldquo;{{ $_GET['s'] }}&rdquo;</p>

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -69,7 +69,7 @@
             <ul id="language" class="input-group input-group__parent language">
               @foreach(App::getMetaValues('language', 'lc_resource') as $language)
               <li>
-                <input id="language-{{ $language }}" name="language[]" type="checkbox" value="{{ $language }}" {{ checked(in_array($language, array_keys($queried_resource_terms['language']))) }} />
+                <input id="language-{{ $language }}" name="resource_language[]" type="checkbox" value="{{ $language }}" {{ checked(in_array($language, array_keys($queried_resource_terms['resource_language']))) }} />
                 <label for="language-{{ $language }}">{!! $languages[$language] !!}</label>
               </li>
               @endforeach


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR fixes a conflict between resource language filtering and Polylang. Resources should now be properly filterable by languag

## Steps to test

1. Visit the Browse all page in various languages.
2. Filter resources by language.

**Expected behavior:** Visiting the resource page in non-English languages should no longer present a default filter with the language applied. Resources should be properly filterable by resource language.

## Additional information

Not applicable.

## Related issues

- Resolves #237.
