### PR TITLE
fix: properly handle new publication date formatting (resolves #245)

### DIFF
--- a/app/Controllers/Partials/Resource.php
+++ b/app/Controllers/Partials/Resource.php
@@ -79,8 +79,17 @@ trait Resource
             }
             $date = get_post_meta($post->ID, 'lc_resource_publication_date', true);
 
-            if ($date !== 'ongoing') {
-                return date_i18n($format, strtotime($date));
+            if ($date !== '–') {
+                $parts = explode('-', $date);
+                if (count($parts) === 3) {
+                    return date_i18n($format, strtotime($date)); // TODO: Fix this
+                }
+                if (count($parts) === 2) {
+                    return date_i18n('F Y', strtotime($date));
+                }
+                if (count($parts) === 1) {
+                    return $date;
+                }
             }
         }
 

--- a/resources/views/partials/content-lc_resource.blade.php
+++ b/resources/views/partials/content-lc_resource.blade.php
@@ -33,7 +33,7 @@
       <span class="separator">.</span>
       @endif
       @if(Archive::getPublicationDate())
-      <span class="card__date"><span class="screen-reader-text">{{ __('date published', 'coop-library') }}: </span>{{ Archive::getPublicationDate('Y') }}</span>
+      <span class="card__date"><span class="screen-reader-text">{{ __('date published', 'coop-library') }}: </span>{{ Archive::getPublicationDate('F Y') }}</span>
       @endif
     </div>
     @endif


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR incorporates changes from https://github.com/platform-coop-toolkit/coop-library-framework/pull/334 and fixes an issue where publication dates that only consisted of a year or a year and a month would be incorrectly formatted.

## Steps to test

1. Visit "Browse All" and sort by publication date.
2. Visit resources with year, year and month, and year, month, and day publication dates.

**Expected behavior:** Publication dates are formatted correctly no matter how many components are provided; resources can be sorted properly by publication date.

## Additional information

Not applicable.

## Related issues

- Requires https://github.com/platform-coop-toolkit/coop-library-framework/pull/334.
- Resolves #245.