### PR TITLE
feat: add notification for filtered search with no results (fix #249)

### DIFF
--- a/resources/assets/scripts/routes/archive.js
+++ b/resources/assets/scripts/routes/archive.js
@@ -15,9 +15,13 @@ export default {
 
     if (document.body.classList.contains('filtered')) {
       const currentFilterCount = document.body.dataset.filters;
+      let msg = sprintf(_n('%s filter applied. Resource list updated.', '%s filters applied. Resource list updated.', parseInt(currentFilterCount), 'coop-library'), currentFilterCount);
+      if (document.body.classList.contains('search-no-results')) {
+        msg = sprintf(_n('%s filter applied. No resources found.', '%s filters applied. No resources found.', parseInt(currentFilterCount), 'coop-library'), currentFilterCount);
+      }
       if ( currentFilterCount ) {
         setTimeout(function() {
-          speak(sprintf(_n('%s filter applied. Resource list updated.', '%s filters applied. Resource list updated.', parseInt(currentFilterCount), 'coop-library'), currentFilterCount), 'assertive');
+          speak(msg, 'assertive');
         }, 1000);
       }
     }

--- a/resources/assets/styles/layouts/_pages.scss
+++ b/resources/assets/styles/layouts/_pages.scss
@@ -32,7 +32,8 @@
   }
 }
 
-.search-results .notification {
+.search-results .notification,
+.search-no-results .notification {
   margin-top: rem(30);
 }
 
@@ -43,13 +44,15 @@
 }
 
 @include breakpoint-up(md) {
-  .search-results .notification {
+  .search-results .notification,
+  .search-no-results .notification {
     @include grid-column-span(6, 8);
   }
 }
 
 @include breakpoint-up(lg) {
-  .search-results .notification {
+  .search-results .notification,
+  .search-no-results .notification {
     @include grid-column-span(8, 12, 5);
 
     margin-top: rem(30);
@@ -66,7 +69,8 @@
 }
 
 @include breakpoint-up(xl) {
-  .search-results .notification {
+  .search-results .notification,
+  .search-no-results .notification {
     @include grid-column-span(8, 16, 5);
   }
 }

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -16,7 +16,9 @@
         @endforeach
       @endforeach
     </ul>
+    @if($found_posts > 0)
     <p><em>{{ __('The resources shown match at least one of these filters.', 'coop-library') }}</em></p>
+    @endif
     <p><a href="{{ get_post_type_archive_link('lc_resource') }}">{{ __('Clear all', 'coop-library') }}</a></p>
   @endif
 </div>

--- a/resources/views/search.blade.php
+++ b/resources/views/search.blade.php
@@ -2,17 +2,20 @@
 
 @section('content')
   @include('partials.page-header')
-
   @if (!have_posts())
-    <div class="alert alert-warning">
-      {{ __('Sorry, no results were found.', 'coop-library') }}
-    </div>
-    @include('partials.search-form', ['placeholder' => __('Search resource name, publisher, or topic…')])
+  <div class="notification notification--warning">
+    <button class="button button--borderless"><svg class="icon icon--close" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path id="close" d="m11.41 10 4.3-4.29a1 1 0 1 0 -1.42-1.42l-4.29 4.3-4.29-4.3a1 1 0 0 0 -1.42 1.42l4.3 4.29-4.3 4.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l4.29-4.3 4.29 4.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z" fill="currentColor"/></svg>
+      <span class="screen-reader-text">{{ __('Close notification', 'coop-library') }}</span></button>
+      <p class="notification__title"><svg class="icon icon--warning" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><g id="warning" fill="currentColor"><path d="m10 1a9.05 9.05 0 1 0 9.05 9 9.06 9.06 0 0 0 -9.05-9zm0 16.1a7.05 7.05 0 1 1 7.05-7 7.05 7.05 0 0 1 -7.05 6.95z"/><path d="m10.09 5.59a1 1 0 0 0 -1 1v4a1 1 0 0 0 2 0v-4a1 1 0 0 0 -1-1z"/><path d="m10.11 12.6a1 1 0 1 0 1 1 1 1 0 0 0 -1-1z"/></g></svg> {{ __('No results for search', 'coop-library') }}</p>
+      <div class="notification__content">{{ __('Sorry, no results were found.', 'coop-library') }}</div>
+  </div>
   @endif
 
   @include('partials.filters')
   @include('partials.sort')
+  @if (have_posts())
   @include('partials.save-search')
+  @endif
   @include('partials.current-filters')
   <div class="resource-list">
     <ul class="cards">

--- a/resources/views/search.blade.php
+++ b/resources/views/search.blade.php
@@ -3,10 +3,10 @@
 @section('content')
   @include('partials.page-header')
   @if (!have_posts())
-  <div class="notification notification--warning">
+  <div class="notification notification--error">
     <button class="button button--borderless"><svg class="icon icon--close" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path id="close" d="m11.41 10 4.3-4.29a1 1 0 1 0 -1.42-1.42l-4.29 4.3-4.29-4.3a1 1 0 0 0 -1.42 1.42l4.3 4.29-4.3 4.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l4.29-4.3 4.29 4.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z" fill="currentColor"/></svg>
       <span class="screen-reader-text">{{ __('Close notification', 'coop-library') }}</span></button>
-      <p class="notification__title"><svg class="icon icon--warning" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><g id="warning" fill="currentColor"><path d="m10 1a9.05 9.05 0 1 0 9.05 9 9.06 9.06 0 0 0 -9.05-9zm0 16.1a7.05 7.05 0 1 1 7.05-7 7.05 7.05 0 0 1 -7.05 6.95z"/><path d="m10.09 5.59a1 1 0 0 0 -1 1v4a1 1 0 0 0 2 0v-4a1 1 0 0 0 -1-1z"/><path d="m10.11 12.6a1 1 0 1 0 1 1 1 1 0 0 0 -1-1z"/></g></svg> {{ __('No results for search', 'coop-library') }}</p>
+      <p class="notification__title"><svg class="icon icon--error" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><g id="error" fill="currentColor"><path d="m10.09 1a9 9 0 1 0 9 9 9 9 0 0 0 -9-9zm0 16a7 7 0 1 1 7-7 7 7 0 0 1 -7 7z"/><path d="m12.85 7.18a1 1 0 0 0 -1.41 0l-1.35 1.35-1.35-1.35a1 1 0 0 0 -1.41 0 1 1 0 0 0 0 1.42l1.35 1.4-1.35 1.29a1 1 0 0 0 1.41 1.42l1.35-1.35 1.35 1.35a1 1 0 0 0 1.41-1.42l-1.35-1.29 1.35-1.4a1 1 0 0 0 0-1.42z"/></g></svg> {{ __('No results for search', 'coop-library') }}</p>
       <div class="notification__content">{{ __('Sorry, no results were found.', 'coop-library') }}</div>
   </div>
   @endif


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Adds assertive and visual notifications for filtered search results which produce zero matches.

## Steps to test

1. Search for "capitalism".
2. Filter by sector: "Childcare & Hospice".

**Expected behavior:** Screen reader announces "1 filter applied. No resources found." A visible notice is added to the screen.

## Additional information

Not applicable.

## Related issues

- Resolves #249.