### PR TITLE
fix: don't cache favorites page (fix #252)

### DIFF
--- a/resources/views/page-favorites.blade.php
+++ b/resources/views/page-favorites.blade.php
@@ -4,6 +4,7 @@
 @extends('layouts.app')
 
 @section('content')
+  @php(define('DONOTCACHEPAGE', true))
   @while(have_posts()) @php the_post() @endphp
     @include('partials.page-header')
     @include('partials.content-page-favorites')

--- a/resources/views/page-favorites.blade.php
+++ b/resources/views/page-favorites.blade.php
@@ -4,7 +4,7 @@
 @extends('layouts.app')
 
 @section('content')
-  @php(define('DONOTCACHEPAGE', true))
+  @php define('DONOTCACHEPAGE', true) @endphp
   @while(have_posts()) @php the_post() @endphp
     @include('partials.page-header')
     @include('partials.content-page-favorites')


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR prevents W3 Total Cache from caching the favorites page, which prevented user favorites from appearing when added.

## Steps to test

1. Install and enable [W3 Total Cache](https://wordpress.org/plugins/w3-total-cache/).
2. Open the site in a private window.
3. Add a couple resources to your favorites.

**Expected behavior:** The resources appear on your favorites page.

## Additional information

Not applicable.

## Related issues

- Resolves #252.