### PR TITLE
feat: simplify language behaviour

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -40,11 +40,24 @@ class App extends Controller
         return false;
     }
 
+    public function languagesWithResources()
+    {
+        if (function_exists('pll_languages_list') && function_exists('pll_count_posts')) {
+            $langs = pll_languages_list(['hide_empty' => 1]);
+            foreach ($langs as $key => $lang) {
+                if (pll_count_posts($lang, ['post_type' => 'lc_resource']) === 0) {
+                    unset($langs[$key]);
+                }
+            }
+            return $langs;
+        }
+    }
+
     public function queriedResourceTerms()
     {
         $langs = get_language_list(pll_current_language('locale'));
         $terms = [
-            'resource_language' => [],
+            'language' => [],
             'lc_format' => [],
             'lc_goal' => [],
             'lc_region' => [],
@@ -55,16 +68,9 @@ class App extends Controller
         global $wp_query;
         if ($wp_query->tax_query) {
             foreach ($wp_query->tax_query->queries as $value) {
-                if ($value['taxonomy'] !== 'language') {
-                    foreach ($value['terms'] as $t) {
-                        $terms[$value['taxonomy']][$t] = get_term_by('slug', $t, $value['taxonomy'])->name;
-                    }
+                foreach ($value['terms'] as $t) {
+                    $terms[$value['taxonomy']][$t] = get_term_by('slug', $t, $value['taxonomy'])->name;
                 }
-            }
-        }
-        if (isset($_GET['resource_language'])) {
-            foreach ($_GET['resource_language'] as $lang) {
-                $terms['resource_language'][ $lang ] = $langs[$lang];
             }
         }
         return $terms;
@@ -79,11 +85,6 @@ class App extends Controller
                 foreach ($value['terms'] as $t) {
                     $count++;
                 }
-            }
-        }
-        if (isset($_GET['language'])) {
-            foreach ($_GET['language'] as $lang) {
-                $count++;
             }
         }
         return $count;
@@ -395,7 +396,7 @@ class App extends Controller
         return $navigation;
     }
 
-    public static function totalPosts($post_type = null, $lang = 'en')
+    public static function totalPosts($post_type = null, $lang = '')
     {
         if ($post_type) {
             $q = new \WP_Query([

--- a/app/Controllers/Partials/Resource.php
+++ b/app/Controllers/Partials/Resource.php
@@ -225,17 +225,30 @@ trait Resource
 
     public static function getRegion()
     {
+        $results = false;
+
         global $post;
 
         if ($post->post_type == 'lc_resource') {
             $regions = wp_get_object_terms($post->ID, 'lc_region', ['order' => 'DESC', 'orderby' => 'count']);
             if ($regions) {
-                $region = maybe_swap_term($regions[0]);
-                return $region->name;
+                $results = [];
+                foreach ($regions as $region) {
+                    if (get_query_var('region') === $region->term_id) {
+                        $results = maybe_swap_term($region)->name;
+                    } elseif (get_term_children($region->$term_id, 'lc_region')) {
+                        $results = maybe_swap_term($region)->name;
+                    } else {
+                        $results[] = maybe_swap_term($region)->name;
+                    }
+                }
+            }
+            if (is_array($results)) {
+                $results = natural_language_join($results);
             }
         }
 
-        return false;
+        return $results;
     }
 
     public static function getGoals($limit = 0)

--- a/app/filters.php
+++ b/app/filters.php
@@ -100,7 +100,7 @@ add_filter('query_vars', function ($vars) {
  */
 add_filter('pre_get_posts', function ($query) {
     if (!is_admin()) {
-        if ((is_post_type_archive('lc_resource') || is_tax()) && $query->is_main_query() || is_search() && $query->is_main_query()) {
+        if ((is_post_type_archive('lc_resource') || is_tax()) && $query->is_main_query() || is_search() && $query->is_main_query()) { // @codingStandardsIgnoreLine
             if (isset($_GET['order_by'])) {
                 switch ($_GET['order_by']) {
                     case 'published':

--- a/app/filters.php
+++ b/app/filters.php
@@ -135,20 +135,13 @@ add_filter('pre_get_posts', function ($query) {
                         break;
                 }
             }
-            if (isset($_GET['resource_language'])) {
-                $meta_query = [
-                    'relation' => 'OR'
-                ];
-                foreach ($_GET['resource_language'] as $lang) {
-                    $meta_query[] = [
-                        'key' => 'language',
-                        'value' => $lang,
-                    ];
-                }
-                $query->set('meta_query', $meta_query);
-            }
             $query->set('posts_per_page', 12);
             $query->set('order', 'desc');
+            if (isset($_GET['lang'])) {
+                $query->set('lang', implode(',', $_GET['lang']));
+            } else {
+                $query->set('lang', '');
+            }
         }
     }
 });

--- a/app/setup.php
+++ b/app/setup.php
@@ -18,11 +18,13 @@ add_action('wp_enqueue_scripts', function () {
         file_get_contents(dirname(__FILE__) . '/../dist/scripts/manifest.js'),
         'before'
     );
-    wp_localize_script('coop-library/main.js', 'CoopLibrary', [
-        'ajaxurl' => admin_url('admin-ajax.php'),
-        'coop_library_nonce' => wp_create_nonce('coop-library-framework-nonce'),
-        'savedSearchesLink' => get_permalink(pll_get_post(get_page_by_path('my-resources/saved-searches')->ID))
-    ]);
+    if (function_exists('pll_get_post')) {
+        wp_localize_script('coop-library/main.js', 'CoopLibrary', [
+            'ajaxurl' => admin_url('admin-ajax.php'),
+            'coop_library_nonce' => wp_create_nonce('coop-library-framework-nonce'),
+            'savedSearchesLink' => get_permalink(pll_get_post(get_page_by_path('my-resources/saved-searches')->ID))
+        ]);
+    }
 
     if (is_single() && comments_open() && get_option('thread_comments')) {
         wp_enqueue_script('comment-reply');

--- a/resources/views/partials/content-front-page.blade.php
+++ b/resources/views/partials/content-front-page.blade.php
@@ -27,6 +27,8 @@
           <li class="card__wrapper">@include('partials.content-'.get_post_type())</li>
         @endwhile
       </ul>
+      @else
+      <p>{{ sprintf(__('No %s found', 'coop-library'), __('resources', 'coop-library')) }}</p>
       @endif
     </div>
     {{-- TODO: Add info cards --}}
@@ -39,6 +41,8 @@
         @include('partials.content-'.get_post_type())
       @endwhile
     </ul>
+    @else
+    <p>{{ sprintf(__('No %s found', 'coop-library'), __('resources', 'coop-library')) }}</p>
     @endif
   </div>
 </section>

--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -24,5 +24,5 @@
     @endif
   @endforeach
 @else
-  <p>{{ sprintf(__('No %s found.'), strtolower(get_the_title())) }}</p>
+  <p>{{ sprintf(__('No %s found.', 'coop-library'), strtolower(get_the_title())) }}</p>
 @endif

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -1,6 +1,6 @@
-@if(isset($_GET['s']) || $found_posts < App::totalPosts('lc_resource', $current_language))
+@if(isset($_GET['s']) || $found_posts < App::totalPosts('lc_resource'))
 <div class="current-filters">
-  <p class="h3">{{ sprintf(__('%1$s of %2$s resources matched', 'coop-library'), $found_posts, App::totalPosts('lc_resource', $current_language)) }}</p>
+  <p class="h3">{{ sprintf(__('%1$s of %2$s resources matched', 'coop-library'), $found_posts, App::totalPosts('lc_resource')) }}</p>
   @if(isset($_GET['s']))
   <h2 class="h4">{{ __('Your search term:', 'coop-library') }}</h2>
   <p>&ldquo;{{ $_GET['s'] }}&rdquo;</p>
@@ -11,7 +11,7 @@
       @foreach($queried_resource_terms as $taxonomy => $terms)
         @foreach($terms as $term => $name)
         <li class="tag">
-          <button class="button button--tag-button" data-checkbox="{{ $taxonomy }}-{{ $term }}">{!! sprintf(__('<span class="screen-reader-text">Remove </span>%s<span class="screen-reader-text"> from current filters</span>', 'coop-library'), $name) !!} @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
+          <button class="button button--tag-button" data-checkbox="{{ $taxonomy }}-{{ $term }}">{!! sprintf(__('<span class="screen-reader-text">Remove </span>%s<span class="screen-reader-text"> from current filters</span>', 'coop-library'), ($taxonomy === 'language') ? $languages[$term] : $name) !!} @svg('close', 'icon--close', ['focusable' => 'false', 'aria-hidden' => 'true'])</button>
         </li>
         @endforeach
       @endforeach

--- a/resources/views/partials/current-filters.blade.php
+++ b/resources/views/partials/current-filters.blade.php
@@ -1,4 +1,4 @@
-@if(isset($_GET['s']) || $found_posts < App::totalPosts('lc_resource'))
+@if(isset($_GET['s']) || $filtered)
 <div class="current-filters">
   <p class="h3">{{ sprintf(__('%1$s of %2$s resources matched', 'coop-library'), $found_posts, App::totalPosts('lc_resource')) }}</p>
   @if(isset($_GET['s']))

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -18,7 +18,7 @@
           'lc_region' => __('Locations', 'coop-library'),
           'lc_format' => __('Formats', 'coop-library'),
         ] as $tax => $label)
-        @if(get_terms(['taxonomy' => $tax]))
+        @if(App::activeTerms(['taxonomy' => $tax, 'lang' => '']))
         <div class="accordion__pane @if(isset($_COOKIE['filters-expanded']) && $_COOKIE['filters-expanded'] === "accordion-$tax"){{ ' accordion__pane--expanded' }}@endif" id="accordion-{{ $tax }}">
           <p class="accordion__heading">{{ $label }}</p>
           <div class="accordion__content">
@@ -26,29 +26,29 @@
               <span class="button__label"><span aria-hidden="true">{{ __('Deselect all', 'coop-library') }}</span><span class="screen-reader-text">{{ sprintf(__('Deselect all %s', 'coop-library'), $label) }}</span></span>
             </button>
             <ul id="{{ $tax }}" class="input-group input-group__parent {{ $tax }}">
-              @foreach(get_terms(['taxonomy' => $tax, 'orderby' => 'order']) as $term)
+              @foreach(App::activeTerms(['taxonomy' => $tax, 'orderby' => 'order', 'lang' => '']) as $term)
                 @if(!$term->parent)
                 <li>
-                  <input id="{{ $tax }}-{{ $term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $term->slug }}" {{
+                  <input id="{{ $tax }}-{{ $term->term_id }}" name="{{ str_replace('lc_', '', $tax) }}[]" type="checkbox" value="{{ $term->term_id }}" {{
                   checked(
-                    (in_array($term->slug, array_keys($queried_resource_terms[$tax]), true)) ? $term->slug : false,
-                    $term->slug,
+                    (in_array($term->name, $queried_resource_terms[$tax], true)) ? $term->term_id : false,
+                    $term->term_id,
                     false
                   ) }} />
-                  <label for="{{ $tax }}-{{ $term->slug }}">{!! $term->name !!}</label>
+                  <label for="{{ $tax }}-{{ $term->term_id }}">{!! $term->name !!}</label>
                   @if(get_term_children($term->term_id, $tax))
                     <span class="supplementary-label" hidden> ({{ sprintf(__('and %d subtopics', 'coop-library'), count(get_term_children($term->term_id, $tax))) }})</span>
                     <span class="filter-disclosure-label" hidden>{{ sprintf(__('show %1$d subtopics for "%2$s"', 'coop-library'), count(get_term_children($term->term_id, $tax)), $term->name) }}</span>
                     <ul class="input-group input-group__descendant">
-                      @foreach(get_terms(['taxonomy' => $tax, 'parent' => $term->term_id]) as $child_term)
+                      @foreach(App::activeTerms(['taxonomy' => $tax, 'parent' => $term->term_id, 'hide_empty' => false, 'lang' => '']) as $child_term)
                       <li>
-                        <input id="{{ $tax }}-{{ $child_term->slug }}" name="{{ $tax }}[]" type="checkbox" value="{{ $child_term->slug }}" {{
+                        <input id="{{ $tax }}-{{ $child_term->term_id }}" name="{{ str_replace('lc_', '', $tax) }}[]" type="checkbox" value="{{ $child_term->term_id }}" {{
                         checked(
-                          (in_array($child_term->slug, array_keys($queried_resource_terms[$tax]), true)) ? $child_term->slug : false,
-                          $child_term->slug,
+                          (in_array($child_term->name, $queried_resource_terms[$tax], true)) ? $child_term->term_id : false,
+                          $child_term->term_id,
                           false
                         ) }} />
-                        <label for="{{ $tax }}-{{ $child_term->slug }}">{!! $child_term->name !!}</label>
+                        <label for="{{ $tax }}-{{ $child_term->term_id }}">{!! $child_term->name !!}</label>
                       </li>
                       @endforeach
                     </ul>
@@ -70,7 +70,7 @@
             <ul id="language" class="input-group input-group__parent language">
               @foreach($languages_with_resources as $language)
               <li>
-                <input id="language-{{ $language }}" name="lang[]" type="checkbox" value="{{ $language }}" {{ checked(in_array($language, array_keys($queried_resource_terms['language']))) }} />
+                <input id="language-{{ $language }}" name="language[]" type="checkbox" value="{{ $language }}" {{ checked(in_array($language, $queried_resource_terms['language'])) }} />
                 <label for="language-{{ $language }}">{!! $languages[$language] !!}</label>
               </li>
               @endforeach

--- a/resources/views/partials/filters.blade.php
+++ b/resources/views/partials/filters.blade.php
@@ -68,9 +68,9 @@
               <span class="button__label">{{ __('Deselect all', 'coop-library') }}<span class="screen-reader-text"> {{ __('languages', 'coop-library') }}</span></span>
             </button>
             <ul id="language" class="input-group input-group__parent language">
-              @foreach(App::getMetaValues('language', 'lc_resource') as $language)
+              @foreach($languages_with_resources as $language)
               <li>
-                <input id="language-{{ $language }}" name="resource_language[]" type="checkbox" value="{{ $language }}" {{ checked(in_array($language, array_keys($queried_resource_terms['resource_language']))) }} />
+                <input id="language-{{ $language }}" name="lang[]" type="checkbox" value="{{ $language }}" {{ checked(in_array($language, array_keys($queried_resource_terms['language']))) }} />
                 <label for="language-{{ $language }}">{!! $languages[$language] !!}</label>
               </li>
               @endforeach


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR simplifies language behaviour in a number of ways:

1. Resource language is determined by Polylang language settings rather than metadata (see https://github.com/platform-coop-toolkit/coop-library-framework/pull/417).
2. Resource archives always show resources in languages unless a filter is applied.
3. Polylang is used to create a filter list of the current languages' equivalents of all terms across all languages which have resources assigned. Filtering by a term in the current language retrieves all resources in all languages assigned to translations of that term.

Nothing looks different on the front end, but the database handling and behaviour under the hood is a lot simpler. 

## Steps to test

1. Visit "Browse all resources" page.
2. Test filtering.
3. Test searching.

**Expected behavior:** It works across languages.

## Additional information

See:

- https://github.com/polylang/polylang/issues/223
- https://wordpress.org/support/topic/polylangcount-posts-using-get_term_by/
- https://wordpress.org/support/topic/problem-with-wp_query-and-polylang/
- https://wordpress.stackexchange.com/questions/35196/theres-a-way-to-use-query-settax-query-in-pre-get-posts-filter/

## Related issues

Depends on https://github.com/platform-coop-toolkit/coop-library-framework/pull/417.
