### PR TITLE
fix: invert analytics settings

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -27,14 +27,14 @@ class App extends Controller
         }
     }
 
-    public function trackViewedResources()
+    public function doNotTrackViewedResources()
     {
-        if (isset($_POST['track_viewed_resources']) && $_POST['track_viewed_resources'] === 'on') {
+        if (isset($_POST['do_not_track_viewed_resources']) && $_POST['do_not_track_viewed_resources'] === 'on') {
             return 'on';
-        } elseif (isset($_POST['track_viewed_resources']) && $_POST['track_viewed_resources'] === '') {
+        } elseif (isset($_POST['do_not_track_viewed_resources']) && $_POST['do_not_track_viewed_resources'] === '') {
             return false;
         }
-        if (isset($_COOKIE['track_viewed_resources']) && $_COOKIE['track_viewed_resources'] === 'on') {
+        if (isset($_COOKIE['do_not_track_viewed_resources']) && $_COOKIE['do_not_track_viewed_resources'] === 'on') {
             return 'on';
         }
         return false;

--- a/app/filters.php
+++ b/app/filters.php
@@ -210,8 +210,8 @@ add_filter('wp_nav_menu_items', function ($items, $args) {
 }, 10, 2);
 
 add_filter('koko_analytics_load_tracking_script', function () {
-    if (isset($_COOKIE['track_viewed_resources']) && $_COOKIE['track_viewed_resources'] === 'on') {
-        return true;
+    if (isset($_COOKIE['do_not_track_viewed_resources']) && $_COOKIE['do_not_track_viewed_resources'] === 'on') {
+        return false;
     }
-    return false;
+    return true;
 });

--- a/app/setup.php
+++ b/app/setup.php
@@ -103,10 +103,10 @@ add_action('wp_ajax_nopriv_update_favorites', 'App\\update_favorites');
  * Set language cookies when settings form is submitted.
  */
 add_action('init', function () {
-    if (isset($_POST['track_viewed_resources'])) {
+    if (isset($_POST['do_not_track_viewed_resources'])) {
         setcookie(
-            'track_viewed_resources',
-            sanitize_text_field($_POST['track_viewed_resources']),
+            'do_not_track_viewed_resources',
+            sanitize_text_field($_POST['do_not_track_viewed_resources']),
             time() + YEAR_IN_SECONDS,
             COOKIEPATH,
             COOKIE_DOMAIN

--- a/resources/views/partials/content-page-settings.blade.php
+++ b/resources/views/partials/content-page-settings.blade.php
@@ -13,11 +13,11 @@
   </div>
   <ul class="input-group">
     <li>
-      <input id="allow" type="radio" name="track_viewed_resources" value="on" {{ checked('on', $track_viewed_resources) }}>
+      <input id="allow" type="radio" name="do_not_track_viewed_resources" value="" {{ checked(false, $do_not_track_viewed_resources) }}>
       <label for="allow">{!! __('Allow', 'coop-library') !!}</label>
     </li>
     <li>
-      <input id="disallow" type="radio" name="track_viewed_resources" value="" {{ checked(false, $track_viewed_resources) }}>
+      <input id="disallow" type="radio" name="do_not_track_viewed_resources" value="on" {{ checked('on', $do_not_track_viewed_resources) }}>
       <label for="disallow">{!! __('Don&rsquo;t allow', 'coop-library') !!}</label>
     </li>
   </ul>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR defaults to allowing analytics to be collected. It's possible that the previous default was preventing some visits from being recorded.

## Steps to test

1. Clear cookies
2. Visit settings page.

**Expected behavior:** Allow tracking is enabled by default.

## Additional information

Not applicable.

## Related issues

Not applicable.
