### PR TITLE
fix: ensure that searches are performed in the current language

### DIFF
--- a/app/Controllers/App.php
+++ b/app/Controllers/App.php
@@ -131,6 +131,15 @@ class App extends Controller
         return $unique;
     }
 
+    public function homeUrl()
+    {
+        if (function_exists('pll_home_url')) {
+            return pll_home_url();
+        }
+
+        return home_url();
+    }
+
     public function filterCount()
     {
         $count = 0;

--- a/resources/views/partials/search-form.blade.php
+++ b/resources/views/partials/search-form.blade.php
@@ -1,4 +1,4 @@
-<form role="search" method="get" class="search-form @if(isset($modifier))search-form--{{ $modifier }}@endif" action="{{ home_url() }}">
+<form role="search" method="get" class="search-form @if(isset($modifier))search-form--{{ $modifier }}@endif" action="{{ $home_url }}">
   <label>
     <span class="screen-reader-text">{{ __('Search for:', 'coop-library') }}</span>
     <input type="search" class="search-field"@if(isset($placeholder)) placeholder="{{ $placeholder }}"@endif value="@if(isset($_GET['s'])){{ $_GET['s'] }}@endif" name="s">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

This PR ensures that search forms are submitted in the current language.

## Steps to test

1. Switch to a language other than English.
2. Perform a search.

**Expected behavior:** Results page is shown in the current (non-English) language.

## Additional information

Not applicable.

## Related issues

Not applicable.
