### PR TITLE
fix: fix incorrect variable

### DIFF
--- a/resources/views/partials/content-term-list.blade.php
+++ b/resources/views/partials/content-term-list.blade.php
@@ -12,7 +12,7 @@
           </li>
           @foreach(App::activeTerms(['taxonomy' => $taxonomy, 'parent' => $term->term_id, 'hide_empty' => false, 'lang' => '']) as $child_term)
           <li class="link-list__item">
-            <a href="{{ App::filteredLink($childterm) }}">{!! $child_term->name !!}</a>
+            <a href="{{ App::filteredLink($child_term) }}">{!! $child_term->name !!}</a>
           </li>
           @endforeach
         </ul>


### PR DESCRIPTION
platform-coop-toolkit / coop-library

* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Fixes broken links on "Explorer" menu pages

## Steps to test

1. Test links with page filters https://resources.platform.coop/topics/
2. Test links with page filters https://resources.platform.coop/goals/
3. Test links with page filters https://resources.platform.coop/formats/
4. Test links with page filters https://resources.platform.coop/sectors/

**Expected behavior:** the links should look like this: https://resources.platform.coop/resources/?filtered=1&sector[]=2804

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here. -->
